### PR TITLE
fix: sourceImage's CreatedAt timestamp should not be included in cach…

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -113,7 +113,11 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 	l := snapshot.NewLayeredMap(hasher)
 	snapshotter := snapshot.NewSnapshotter(l, config.RootDir)
 
-	digest, err := sourceImage.Digest()
+	sourceImageNoTimestamps, err := mutate.CreatedAt(sourceImage, v1.Time{})
+	if err != nil {
+		return nil, err
+	}
+	digest, err := sourceImageNoTimestamps.Digest()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…e key

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
