### PR TITLE
kaniko learned '--materialize' forcing the filesystem into a well-defined state after the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ _If you are interested in contributing to kaniko, see
       - [Flag `--label`](#flag---label)
       - [Flag `--log-format`](#flag---log-format)
       - [Flag `--log-timestamp`](#flag---log-timestamp)
+      - [Flag `--materialize`](#flag---materialize)
       - [Flag `--no-push`](#flag---no-push)
       - [Flag `--no-push-cache`](#flag---no-push-cache)
       - [Flag `--oci-layout-path`](#flag---oci-layout-path)
@@ -943,6 +944,14 @@ Defaults to `color`.
 
 Set this flag as `--log-timestamp=<true|false>` to add timestamps to
 `<text|color>` log format. Defaults to `false`.
+
+#### Flag `--materialize`
+
+Set this boolean flag to `true` if you want kaniko to ensure that the filesystem is in a well-defined state after the build finishes. If you have a 100% cache-hitrate kaniko can skip unpacking files to the filesystem as it is superfluous if the goal is to simply build an image and push it to registry, but this also means that state of the filesystem after the build depends on whether that optimization was possible or not. This option disables this optimization entirely making sure that the filesystem is always well-defined.
+
+This is useful if you use kaniko not to build a docker image, but to initialize your environment.
+
+Defaults to `false`
 
 #### Flag `--no-push`
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -281,6 +281,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.ForceBuildMetadata, "force-build-metadata", "", false, "Force add metadata layers to build image")
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipPushPermissionCheck, "skip-push-permission-check", "", false, "Skip check of the push permission")
 	RootCmd.PersistentFlags().BoolVarP(&opts.PreserveContext, "preserve-context", "", false, "Preserve build context accross build stages by taking a snapshot of the full filesystem before build and restore it after we switch stages. Restores in the end too if passed together with 'cleanup'")
+	RootCmd.PersistentFlags().BoolVarP(&opts.Materialize, "materialize", "", false, "Guarantee that the final state of the file system corresponds to what was specified as the build target, even if we have 100% cache hitrate and wouldn't need to unpack any layers")
 
 	// Deprecated flags.
 	RootCmd.PersistentFlags().StringVarP(&opts.SnapshotModeDeprecated, "snapshotMode", "", "", "This flag is deprecated. Please use '--snapshot-mode'.")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -92,6 +92,7 @@ type KanikoOptions struct {
 	InitialFSUnpacked        bool
 	SkipPushPermissionCheck  bool
 	PreserveContext          bool
+	Materialize              bool
 }
 
 type KanikoGitOptions struct {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -341,6 +341,9 @@ func (s *stageBuilder) build() error {
 	if len(s.crossStageDeps[s.stage.Index]) > 0 {
 		shouldUnpack = true
 	}
+	if s.stage.Final && s.opts.Materialize {
+		shouldUnpack = true
+	}
 	if s.stage.Index == 0 && s.opts.InitialFSUnpacked {
 		shouldUnpack = false
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
