### PR TITLE
sticky bit gets lost on COPY

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_3393
+++ b/integration/dockerfiles/Dockerfile_test_issue_3393
@@ -1,0 +1,11 @@
+FROM ubuntu
+
+# Fails on main@1d2bff5 before #3393:
+# When we COPY files into an existing folder
+# kaniko will not only copy the permissions from the context
+# onto the newly created files and folders. But will
+# also modify the permissions on the top level folder, even if it pre-exists.
+# This is aberrant behaviour, other build-tools persist the permissions.
+# In this specific case this leads to build-failure as sticky bit is lost on /tmp
+COPY ./ tmp
+RUN apt-get update && apt-get install -y curl

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -864,7 +864,13 @@ func MkdirAllWithPermissionsKeepExistingMode(path string, mode os.FileMode, uid,
 		return errors.Wrapf(err, "error calling stat on %s.", path)
 	}
 
-	if err := os.MkdirAll(path, mode); err != nil {
+	// mkdir respects the process' umask
+	// so we can't copy the correct permissions from source
+	// if umask is set to anything other than 0
+	umask := syscall.Umask(0)
+	err = os.MkdirAll(path, mode)
+	syscall.Umask(umask)
+	if err != nil {
 		return err
 	}
 	if uid > math.MaxUint32 || gid > math.MaxUint32 {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

fixes https://github.com/GoogleContainerTools/kaniko/issues/3393

**Description**

When we `COPY` a folder structure into an existing folder both docker & kaniko will merge the contents. However the behaviour of kaniko and docker diverges when it comes to permissions and file-mode. docker will keep the permissions and mode of the existing directories. kaniko will override them with whatever permissions were in the outside context. This is the worse implementation as gets obvious with the Dockerfile example of the issue author, where the sticky bit is lost on `/tmp` if we `COPY` there, causing subsequent build failure.

The fix is simple, do not overwrite the permissions for existing folders, that's it.

Turns out it was more complicated than I initially assumed. The overriding was crucial for COPY in some scenarios, not because the existing folders should change the mode, but because mkdir created new folders with wrong modes! The reason, the umask of the process. So the solution is twofold, yes we should preserve the file-modes on COPY, but we also must make sure that umask doesn't interfere with this process.

Further, for untarring it is crucial that we do force the mode and permissions, as otherwise it would be impossible to store a file-mode change in cache.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
