### PR TITLE
cache collision under rename

### DIFF
--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -108,6 +108,21 @@ func hashDir(p string, context util.FileContext) (bool, string, error) {
 		if err != nil {
 			return err
 		}
+
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+
+		absRoot, err := filepath.Abs(context.Root)
+		if err != nil {
+			return err
+		}
+
+		if _, err := sha.Write([]byte(strings.TrimPrefix(absPath, absRoot))); err != nil {
+			return err
+		}
+
 		if _, err := sha.Write([]byte(fileHash)); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

copied from https://github.com/GoogleContainerTools/kaniko/pull/3203

fixes https://github.com/GoogleContainerTools/kaniko/issues/2241 https://github.com/GoogleContainerTools/kaniko/issues/1678

**Description**

I manually verified that the issue is still there and that the proposed fix is sufficient.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
