### PR TITLE
COPY --chmod doesn't change existing directories

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz108
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz108
@@ -1,0 +1,11 @@
+FROM debian
+
+USER nobody
+
+# Fails on main@ad721d2 before #108:
+# When we COPY --chmod on top of an existing folder,
+# the chmod only affects existing files,
+# but is ignored on existing folders
+COPY --chmod=400 context/ /context
+COPY --chmod=755 context/ /context
+RUN ls -la /context

--- a/integration/images.go
+++ b/integration/images.go
@@ -116,7 +116,8 @@ var diffArgsMap = map[string][]string{
 	// if group is not set, buildx defaults to 0
 	"TestRun/test_Dockerfile_test_user_nonexisting": {"--extra-ignore-file-permissions"},
 	// Somehow buildkit sets Uid of copied files to root=0 instead of active user.
-	"TestRun/test_Dockerfile_test_issue_3166": {"--extra-ignore-file-permissions"},
+	"TestRun/test_Dockerfile_test_issue_3166":  {"--extra-ignore-file-permissions"},
+	"TestRun/test_Dockerfile_test_issue_mz108": {"--extra-ignore-file-permissions"},
 }
 
 // output check to do when building with kaniko


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/mzihlmann/kaniko/issues/108

**Description**

This is a regression introduced by https://github.com/mzihlmann/kaniko/pull/45
Back then we disabled the post-copy chmod, s.t. mods are only set on new directories. This is fine and all if we do regular COPY, but for COPY --chmod the expectation is that even existing dirs are updated.

With this change we again do forceful override of existing dirs, but only if chmod is passed, so making both scenarios happy.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
