### PR TITLE
new cli option to select credential helpers

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -281,6 +281,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipPushPermissionCheck, "skip-push-permission-check", "", false, "Skip check of the push permission")
 	RootCmd.PersistentFlags().BoolVarP(&opts.PreserveContext, "preserve-context", "", false, "Preserve build context accross build stages by taking a snapshot of the full filesystem before build and restore it after we switch stages. Restores in the end too if passed together with 'cleanup'")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Materialize, "materialize", "", false, "Guarantee that the final state of the file system corresponds to what was specified as the build target, even if we have 100% cache hitrate and wouldn't need to unpack any layers")
+	RootCmd.PersistentFlags().VarP(&opts.CredentialHelpers, "credential-helpers", "", "Use these credential helpers automatically, select from (google, ecr, acr, gitlab). Set it repeatedly for multiple helpers, defaults to all, set it to empty string to deactivate.")
 
 	// Deprecated flags.
 	RootCmd.PersistentFlags().StringVarP(&opts.SnapshotModeDeprecated, "snapshotMode", "", "", "This flag is deprecated. Please use '--snapshot-mode'.")

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -73,7 +73,7 @@ func (rc *RegistryCache) RetrieveLayer(ck string) (v1.Image, error) {
 		return nil, errors.Wrapf(err, "making transport for registry %q", registryName)
 	}
 
-	img, err := remote.Image(cacheRef, remote.WithTransport(tr), remote.WithAuthFromKeychain(creds.GetKeychain()))
+	img, err := remote.Image(cacheRef, remote.WithTransport(tr), remote.WithAuthFromKeychain(creds.GetKeychain(&rc.Opts.RegistryOptions)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -46,6 +46,7 @@ type RegistryOptions struct {
 	PushIgnoreImmutableTagErrors bool
 	PushRetry                    int
 	ImageDownloadRetry           int
+	CredentialHelpers            multiArg
 }
 
 // KanikoOptions are options that are set by command line arguments

--- a/pkg/creds/creds.go
+++ b/pkg/creds/creds.go
@@ -19,20 +19,55 @@ package creds
 import (
 	"io"
 
+	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/chrismellard/docker-credential-acr-env/pkg/credhelper"
 	gitlab "github.com/ePirat/docker-credential-gitlabci/pkg/credhelper"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/google"
+	"github.com/sirupsen/logrus"
 )
 
 // GetKeychain returns a keychain for accessing container registries.
-func GetKeychain() authn.Keychain {
-	return authn.NewMultiKeychain(
-		authn.DefaultKeychain,
-		google.Keychain,
-		authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard))),
-		authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper()),
-		authn.NewKeychainFromHelper(gitlab.NewGitLabCredentialsHelper()),
-	)
+func GetKeychain(opts *config.RegistryOptions) authn.Keychain {
+	var helpers []string
+
+	if len(opts.CredentialHelpers) == 0 {
+		helpers = []string{"google", "ecr", "acr", "gitlab"}
+	} else {
+		helpers = opts.CredentialHelpers
+	}
+
+	keychains := []authn.Keychain{authn.DefaultKeychain}
+
+	for _, source := range helpers {
+		switch source {
+		case "":
+			logrus.Info("all credential helpers disabled")
+		case "google":
+			keychains = append(keychains, google.Keychain)
+		case "ecr":
+			keychains = append(keychains,
+				authn.NewKeychainFromHelper(
+					ecr.NewECRHelper(ecr.WithLogger(io.Discard)),
+				),
+			)
+		case "acr":
+			keychains = append(keychains,
+				authn.NewKeychainFromHelper(
+					credhelper.NewACRCredentialsHelper(),
+				),
+			)
+		case "gitlab":
+			keychains = append(keychains,
+				authn.NewKeychainFromHelper(
+					gitlab.NewGitLabCredentialsHelper(),
+				),
+			)
+		default:
+			logrus.Warnf("Unknown cred-source %q, skipping.", source)
+		}
+	}
+
+	return authn.NewMultiKeychain(keychains...)
 }

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -129,7 +129,7 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 			return errors.Wrapf(err, "making transport for registry %q", registryName)
 		}
 		tr := newRetry(rt)
-		if err := checkRemotePushPermission(destRef, creds.GetKeychain(), tr); err != nil {
+		if err := checkRemotePushPermission(destRef, creds.GetKeychain(&opts.RegistryOptions), tr); err != nil {
 			return errors.Wrapf(err, "checking push permission for %q", destRef)
 		}
 		checked[destRef.Context().String()] = true
@@ -271,7 +271,7 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 			destRef.Repository.Registry = newReg
 		}
 
-		pushAuth, err := creds.GetKeychain().Resolve(destRef.Context().Registry)
+		pushAuth, err := creds.GetKeychain(&opts.RegistryOptions).Resolve(destRef.Context().Registry)
 		if err != nil {
 			return errors.Wrap(err, "resolving pushAuth")
 		}

--- a/pkg/image/remote/remote.go
+++ b/pkg/image/remote/remote.go
@@ -159,7 +159,7 @@ func remoteOptions(registryName string, opts config.RegistryOptions, customPlatf
 		logrus.Fatalf("Invalid platform %q: %v", customPlatform, err)
 	}
 
-	return []remote.Option{remote.WithTransport(tr), remote.WithAuthFromKeychain(creds.GetKeychain()), remote.WithPlatform(*platform)}
+	return []remote.Option{remote.WithTransport(tr), remote.WithAuthFromKeychain(creds.GetKeychain(&opts)), remote.WithPlatform(*platform)}
 }
 
 // Parse the registry mapping


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/GoogleContainerTools/kaniko/issues/3328 https://github.com/GoogleContainerTools/kaniko/issues/1984

**Description**

Introduce a new cli option `--credential-helpers` to select which, if any, credential helpers should be automatically detected. This prevents an issue where gitlab's infra leaks unusable credentials via metadata-server into user's CI job. Implemented as suggested by @jameshartig.

specifically the issue with gitlab can now be solved by passing
```
--credential-helpers=gitlab
```
implicitly deactivating GCP's metadata-server as a potential source.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
