### PR TITLE
155: snapshotting preserves atime

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz155
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz155
@@ -8,6 +8,11 @@ RUN mkdir -p /tmp/testdir \
 RUN stat /tmp/testdir \
     && stat /tmp/testdir/file.txt
 
+# assert that snapshot did not touch atime. we can't use diffoci for that,
+# as buildkit does not snapshot atime, they are only present during build.
+RUN [ $(stat -c %X /tmp/testdir) -eq $(date -d '2000-01-01' +%s) ] \
+    && [ $(stat -c %X /tmp/testdir) -eq $(date -d '2000-01-01' +%s) ]
+
 FROM debian:12.10 AS second-image
 
 COPY --from=first-image /tmp/testdir /tmp/testdir

--- a/integration/images.go
+++ b/integration/images.go
@@ -120,7 +120,7 @@ var diffArgsMap = map[string][]string{
 	// which we pass by default, and then activating all the necessary ignores except file-timestamps.
 	// We do ignore /tmp directory as the timestamp on that directory will be altered if we create a new file inside.
 	// for some reason buildkit switches to USTAR instead of PAX format and we don't
-	"TestRun/test_Dockerfile_test_issue_mz155": {"--semantic=false", "--ignore-history", "--ignore-file-meta-format", "--ignore-file-atime", "--ignore-file-ctime", "--extra-ignore-files=tmp/"},
+	"TestRun/test_Dockerfile_test_issue_mz155": {"--semantic=false", "--ignore-history", "--ignore-file-meta-format", "--ignore-file-ctime", "--extra-ignore-files=tmp/"},
 }
 
 // output check to do when building with kaniko

--- a/integration/images.go
+++ b/integration/images.go
@@ -120,7 +120,7 @@ var diffArgsMap = map[string][]string{
 	// which we pass by default, and then activating all the necessary ignores except file-timestamps.
 	// We do ignore /tmp directory as the timestamp on that directory will be altered if we create a new file inside.
 	// for some reason buildkit switches to USTAR instead of PAX format and we don't
-	"TestRun/test_Dockerfile_test_issue_mz155": {"--semantic=false", "--ignore-history", "--ignore-file-meta-format", "--ignore-file-ctime", "--extra-ignore-files=tmp/"},
+	"TestRun/test_Dockerfile_test_issue_mz155": {"--semantic=false", "--ignore-history", "--ignore-file-meta-format", "--ignore-file-atime", "--ignore-file-ctime", "--extra-ignore-files=tmp/"},
 }
 
 // output check to do when building with kaniko

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -219,7 +219,7 @@ func (c *cachedImage) Manifest() (*v1.Manifest, error) {
 }
 
 func mfstFromPath(p string) (*v1.Manifest, error) {
-	f, err := util.NoAtimeFS{}.Open(p)
+	f, err := util.FSys.Open(p)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -219,7 +219,7 @@ func (c *cachedImage) Manifest() (*v1.Manifest, error) {
 }
 
 func mfstFromPath(p string) (*v1.Manifest, error) {
-	f, err := os.Open(p)
+	f, err := util.NoAtimeFS{}.Open(p)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/commands/copy_test.go
+++ b/pkg/commands/copy_test.go
@@ -523,6 +523,10 @@ func Test_CopyEnvAndWildcards(t *testing.T) {
 }
 
 func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
+	_original := util.FSys
+	util.FSys = util.OSFS{}
+	defer func() { util.FSys = _original }()
+
 	setupDirs := func(t *testing.T) (string, string) {
 		testDir := t.TempDir()
 
@@ -758,6 +762,10 @@ func TestCopyCommand_ExecuteCommand_Extended(t *testing.T) {
 	})
 
 	t.Run("copy deadlink symlink file to a dir", func(t *testing.T) {
+		_original := util.FSys
+		util.FSys = util.OSFS{}
+		defer func() { util.FSys = _original }()
+
 		testDir, srcDir := setupDirs(t)
 		defer os.RemoveAll(testDir)
 		doesNotExists := filepath.Join(testDir, "dead.txt")

--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -96,7 +96,7 @@ func (s *CompositeCache) AddPath(p string, context util.FileContext) error {
 func hashDir(p string, context util.FileContext) (bool, string, error) {
 	sha := sha256.New()
 	empty := true
-	if err := filepath.WalkDir(p, func(path string, _ fs.DirEntry, err error) error {
+	if err := fs.WalkDir(util.NoAtimeFS{}, p, func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -96,7 +96,7 @@ func (s *CompositeCache) AddPath(p string, context util.FileContext) error {
 func hashDir(p string, context util.FileContext) (bool, string, error) {
 	sha := sha256.New()
 	empty := true
-	if err := fs.WalkDir(util.NoAtimeFS{}, p, func(path string, _ fs.DirEntry, err error) error {
+	if err := fs.WalkDir(util.FSys, p, func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -156,7 +156,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	// which can lag if sync is not called. Unfortunately there can still be lag if too much data needs
 	// to be flushed or the disk does its own caching/buffering.
 	if runtime.GOOS == "linux" {
-		dir, err := util.NoAtimeFS{}.Open(s.directory)
+		dir, err := util.FSys.Open(s.directory)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -534,6 +534,10 @@ var testResolveSources = []struct {
 }
 
 func Test_ResolveSources(t *testing.T) {
+	_original := FSys
+	FSys = OSFS{}
+	defer func() { FSys = _original }()
+
 	for _, test := range testResolveSources {
 		actualList, err := ResolveSources(test.srcsAndDest, buildContextPath)
 		testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedList, actualList)

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -505,7 +505,8 @@ func RelativeFiles(fp string, root string) ([]string, error) {
 	fullPath := filepath.Join(root, fp)
 	cleanedRoot := filepath.Clean(root)
 	logrus.Debugf("Getting files and contents at root %s for %s", root, fullPath)
-	err := fs.WalkDir(FSys, fullPath, func(path string, _ fs.DirEntry, err error) error {
+	// TODO: #155 somehow fs.WalkDir here causes unittests to fail
+	err := filepath.WalkDir(fullPath, func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -43,6 +43,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// for testing
+var (
+	FSys fs.FS = NoAtimeFS{}
+)
+
 const (
 	DoNotChangeUID = -1
 	DoNotChangeGID = -1
@@ -225,7 +230,7 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 // DeleteFilesystem deletes the extracted image file system
 func DeleteFilesystem() error {
 	logrus.Info("Deleting filesystem...")
-	return fs.WalkDir(NoAtimeFS{}, config.RootDir, func(path string, info fs.DirEntry, err error) error {
+	return fs.WalkDir(FSys, config.RootDir, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			// ignore errors when deleting.
 			return nil //nolint:nilerr
@@ -459,7 +464,7 @@ func checkIgnoreListRoot(root string) bool {
 // From: https://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func DetectFilesystemIgnoreList(path string) error {
 	logrus.Trace("Detecting filesystem ignore list")
-	f, err := os.Open(path)
+	f, err := FSys.Open(path)
 	if err != nil {
 		return err
 	}
@@ -500,7 +505,7 @@ func RelativeFiles(fp string, root string) ([]string, error) {
 	fullPath := filepath.Join(root, fp)
 	cleanedRoot := filepath.Clean(root)
 	logrus.Debugf("Getting files and contents at root %s for %s", root, fullPath)
-	err := fs.WalkDir(NoAtimeFS{}, fullPath, func(path string, _ fs.DirEntry, err error) error {
+	err := fs.WalkDir(FSys, fullPath, func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -771,7 +776,7 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod fs.Fi
 		return false, err
 	}
 	logrus.Debugf("Copying file %s to %s", src, dest)
-	srcFile, err := NoAtimeFS{}.Open(src)
+	srcFile, err := FSys.Open(src)
 	if err != nil {
 		return false, err
 	}
@@ -1018,7 +1023,7 @@ func CopyFileOrSymlink(src string, destDir string, root string) error {
 		Skip: func(info os.FileInfo, src, dest string) (bool, error) {
 			return strings.HasSuffix(src, "/kaniko"), nil
 		},
-		FS: NoAtimeFS{},
+		FS: FSys,
 	}
 	if err := otiai10Cpy.Copy(src, destFile, opts); err != nil {
 		return errors.Wrap(err, "copying file")
@@ -1038,7 +1043,7 @@ func CopyFileOrSymlink(src string, destDir string, root string) error {
 
 // CopyOwnership copies the file or directory ownership recursively at src to dest
 func CopyOwnership(src string, destDir string, root string) error {
-	return fs.WalkDir(NoAtimeFS{}, src, func(path string, info fs.DirEntry, err error) error {
+	return fs.WalkDir(FSys, src, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -1253,7 +1258,7 @@ func gowalkDir(dir string, existingPaths map[string]struct{}, changeFunc func(st
 		return nil
 	}
 
-	err := fs.WalkDir(NoAtimeFS{}, dir, callback)
+	err := fs.WalkDir(FSys, dir, callback)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1292,7 +1297,7 @@ func GetFSInfoMap(dir string, existing map[string]os.FileInfo) (map[string]os.Fi
 		}
 		return nil
 	}
-	err := fs.WalkDir(NoAtimeFS{}, dir, callback)
+	err := fs.WalkDir(FSys, dir, callback)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1316,4 +1321,10 @@ type NoAtimeFS struct{}
 
 func (NoAtimeFS) Open(name string) (fs.File, error) {
 	return os.OpenFile(name, os.O_RDONLY|unix.O_NOATIME, 0)
+}
+
+type OSFS struct{}
+
+func (OSFS) Open(name string) (fs.File, error) {
+	return os.Open(name)
 }

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -225,7 +225,7 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 // DeleteFilesystem deletes the extracted image file system
 func DeleteFilesystem() error {
 	logrus.Info("Deleting filesystem...")
-	return filepath.WalkDir(config.RootDir, func(path string, info fs.DirEntry, err error) error {
+	return fs.WalkDir(NoAtimeFS{}, config.RootDir, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			// ignore errors when deleting.
 			return nil //nolint:nilerr
@@ -500,7 +500,7 @@ func RelativeFiles(fp string, root string) ([]string, error) {
 	fullPath := filepath.Join(root, fp)
 	cleanedRoot := filepath.Clean(root)
 	logrus.Debugf("Getting files and contents at root %s for %s", root, fullPath)
-	err := filepath.WalkDir(fullPath, func(path string, _ fs.DirEntry, err error) error {
+	err := fs.WalkDir(NoAtimeFS{}, fullPath, func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -1038,7 +1038,7 @@ func CopyFileOrSymlink(src string, destDir string, root string) error {
 
 // CopyOwnership copies the file or directory ownership recursively at src to dest
 func CopyOwnership(src string, destDir string, root string) error {
-	return filepath.WalkDir(src, func(path string, info fs.DirEntry, err error) error {
+	return fs.WalkDir(NoAtimeFS{}, src, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -1253,7 +1253,7 @@ func gowalkDir(dir string, existingPaths map[string]struct{}, changeFunc func(st
 		return nil
 	}
 
-	err := filepath.WalkDir(dir, callback)
+	err := fs.WalkDir(NoAtimeFS{}, dir, callback)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1292,7 +1292,7 @@ func GetFSInfoMap(dir string, existing map[string]os.FileInfo) (map[string]os.Fi
 		}
 		return nil
 	}
-	err := filepath.WalkDir(dir, callback)
+	err := fs.WalkDir(NoAtimeFS{}, dir, callback)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -1111,7 +1111,7 @@ func CopyTimestamps(src string, dest string) error {
 	if !ok {
 		return fmt.Errorf("failed to retrieve timestamps from: %s", src)
 	}
-	atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	atime := time.Time{}
 	mtime := time.Unix(int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec))
 	err = os.Chtimes(dest, atime, mtime)
 	if err != nil {

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1012,6 +1012,10 @@ func fakeExtract(_ string, _ *tar.Header, _ string, _ io.Reader) error {
 }
 
 func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) {
+	_original := FSys
+	FSys = OSFS{}
+	defer func() { FSys = _original }()
+
 	resetMountInfoFile := provideEmptyMountinfoFile()
 	defer resetMountInfoFile()
 
@@ -1121,6 +1125,10 @@ func provideEmptyMountinfoFile() func() {
 }
 
 func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T) {
+	_original := FSys
+	FSys = OSFS{}
+	defer func() { FSys = _original }()
+
 	resetMountInfoFile := provideEmptyMountinfoFile()
 	defer resetMountInfoFile()
 
@@ -1224,6 +1232,10 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T)
 }
 
 func Test_GetFSFromLayers_ignorelist(t *testing.T) {
+	_original := FSys
+	FSys = OSFS{}
+	defer func() { FSys = _original }()
+
 	resetMountInfoFile := provideEmptyMountinfoFile()
 	defer resetMountInfoFile()
 

--- a/pkg/util/groupids_fallback.go
+++ b/pkg/util/groupids_fallback.go
@@ -24,7 +24,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"os"
 	"os/user"
 	"strconv"
 	"strings"
@@ -50,7 +49,7 @@ func groupIDs(u *user.User) ([]string, error) {
 		return []string{}, nil
 	}
 
-	f, err := os.Open(groupFile)
+	f, err := NoAtimeFS{}.Open(groupFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "open")
 	}

--- a/pkg/util/groupids_fallback.go
+++ b/pkg/util/groupids_fallback.go
@@ -49,7 +49,7 @@ func groupIDs(u *user.User) ([]string, error) {
 		return []string{}, nil
 	}
 
-	f, err := NoAtimeFS{}.Open(groupFile)
+	f, err := FSys.Open(groupFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "open")
 	}

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -67,7 +67,7 @@ func CreateTarballOfDirectory(pathToDir string, f io.Writer) error {
 		return tarWriter.AddFileToTar(path)
 	}
 
-	return fs.WalkDir(NoAtimeFS{}, pathToDir, walkFn)
+	return fs.WalkDir(FSys, pathToDir, walkFn)
 }
 
 // Close will close any open streams used by Tar.
@@ -132,7 +132,7 @@ func (t *Tar) AddFileToTar(p string) error {
 	if !(i.Mode().IsRegular()) || hardlink {
 		return nil
 	}
-	r, err := NoAtimeFS{}.Open(p)
+	r, err := FSys.Open(p)
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func getSyscallStatT(i os.FileInfo) *syscall.Stat_t {
 func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 	// First, we need to check if the path is a local tar archive
 	if compressed, compressionLevel := fileIsCompressedTar(path); compressed {
-		file, err := NoAtimeFS{}.Open(path)
+		file, err := FSys.Open(path)
 		if err != nil {
 			return nil, err
 		}
@@ -247,7 +247,7 @@ func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 		}
 	}
 	if fileIsUncompressedTar(path) {
-		file, err := NoAtimeFS{}.Open(path)
+		file, err := FSys.Open(path)
 		if err != nil {
 			return nil, err
 		}
@@ -265,7 +265,7 @@ func IsFileLocalTarArchive(src string) bool {
 }
 
 func fileIsCompressedTar(src string) (bool, archive.Compression) {
-	r, err := NoAtimeFS{}.Open(src)
+	r, err := FSys.Open(src)
 	if err != nil {
 		return false, -1
 	}
@@ -279,7 +279,7 @@ func fileIsCompressedTar(src string) (bool, archive.Compression) {
 }
 
 func fileIsUncompressedTar(src string) bool {
-	r, err := NoAtimeFS{}.Open(src)
+	r, err := FSys.Open(src)
 	if err != nil {
 		return false
 	}
@@ -301,7 +301,7 @@ func fileIsUncompressedTar(src string) bool {
 
 // UnpackCompressedTar unpacks the compressed tar at path to dir
 func UnpackCompressedTar(path, dir string) error {
-	file, err := NoAtimeFS{}.Open(path)
+	file, err := FSys.Open(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -67,7 +67,7 @@ func CreateTarballOfDirectory(pathToDir string, f io.Writer) error {
 		return tarWriter.AddFileToTar(path)
 	}
 
-	return filepath.WalkDir(pathToDir, walkFn)
+	return fs.WalkDir(NoAtimeFS{}, pathToDir, walkFn)
 }
 
 // Close will close any open streams used by Tar.

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -132,7 +132,7 @@ func (t *Tar) AddFileToTar(p string) error {
 	if !(i.Mode().IsRegular()) || hardlink {
 		return nil
 	}
-	r, err := os.Open(p)
+	r, err := NoAtimeFS{}.Open(p)
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func getSyscallStatT(i os.FileInfo) *syscall.Stat_t {
 func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 	// First, we need to check if the path is a local tar archive
 	if compressed, compressionLevel := fileIsCompressedTar(path); compressed {
-		file, err := os.Open(path)
+		file, err := NoAtimeFS{}.Open(path)
 		if err != nil {
 			return nil, err
 		}
@@ -247,7 +247,7 @@ func UnpackLocalTarArchive(path, dest string) ([]string, error) {
 		}
 	}
 	if fileIsUncompressedTar(path) {
-		file, err := os.Open(path)
+		file, err := NoAtimeFS{}.Open(path)
 		if err != nil {
 			return nil, err
 		}
@@ -265,7 +265,7 @@ func IsFileLocalTarArchive(src string) bool {
 }
 
 func fileIsCompressedTar(src string) (bool, archive.Compression) {
-	r, err := os.Open(src)
+	r, err := NoAtimeFS{}.Open(src)
 	if err != nil {
 		return false, -1
 	}
@@ -279,7 +279,7 @@ func fileIsCompressedTar(src string) (bool, archive.Compression) {
 }
 
 func fileIsUncompressedTar(src string) bool {
-	r, err := os.Open(src)
+	r, err := NoAtimeFS{}.Open(src)
 	if err != nil {
 		return false
 	}
@@ -301,7 +301,7 @@ func fileIsUncompressedTar(src string) bool {
 
 // UnpackCompressedTar unpacks the compressed tar at path to dir
 func UnpackCompressedTar(path, dir string) error {
-	file, err := os.Open(path)
+	file, err := NoAtimeFS{}.Open(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -62,7 +62,7 @@ func Hasher() func(string) (string, error) {
 			if capability != nil {
 				h.Write(capability)
 			}
-			f, err := NoAtimeFS{}.Open(p)
+			f, err := FSys.Open(p)
 			if err != nil {
 				return "", err
 			}
@@ -100,7 +100,7 @@ func CacheHasher() func(string) (string, error) {
 		h.Write([]byte(strconv.FormatUint(uint64(fi.Sys().(*syscall.Stat_t).Gid), 36)))
 
 		if fi.Mode().IsRegular() {
-			f, err := NoAtimeFS{}.Open(p)
+			f, err := FSys.Open(p)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -62,7 +62,7 @@ func Hasher() func(string) (string, error) {
 			if capability != nil {
 				h.Write(capability)
 			}
-			f, err := os.Open(p)
+			f, err := NoAtimeFS{}.Open(p)
 			if err != nil {
 				return "", err
 			}
@@ -100,7 +100,7 @@ func CacheHasher() func(string) (string, error) {
 		h.Write([]byte(strconv.FormatUint(uint64(fi.Sys().(*syscall.Stat_t).Gid), 36)))
 
 		if fi.Mode().IsRegular() {
-			f, err := os.Open(p)
+			f, err := NoAtimeFS{}.Open(p)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #155

**Description**

Unfortunately can't finish it on my side alone, everytime `os.Open` gets called we run into this issue. I don't see a way how i can monkeypatch it in go, so the only solution is to bring all dependencies to expose os as an interface, that will take some time.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
