### PR TITLE
189: new cli option --pre-cleanup to clean the filesystem prior to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `--cache-copy-layers`](#flag---cache-copy-layers)
       - [Flag `--cache-run-layers`](#flag---cache-run-layers)
       - [Flag `--cache-ttl`](#flag---cache-ttl)
+      - [Flag `--pre-cleanup`](#flag---pre-cleanup)
       - [Flag `--cleanup`](#flag---cleanup)
       - [Flag `--compression`](#flag---compression)
       - [Flag `--compression-level`](#flag---compression-level)
@@ -968,6 +969,11 @@ Set this flag to cache run layers (default=true).
 
 Cache timeout in hours. Defaults to two weeks.
 
+#### Flag `--pre-cleanup`
+
+Set this flag to clean the filesystem before the build.
+ie. in order to support custom built kaniko images.
+
 #### Flag `--cleanup`
 
 Set this flag to clean the filesystem at the end of the build.
@@ -1128,11 +1134,11 @@ be either `application/vnd.oci.image.manifest.v1+json` or
 #### Flag `--preserve-context`
 
 Set this boolean flag to `true` if you want kaniko to restore the build-context for multi-stage builds.
-If set, kaniko will take a snapshot of the full filesystem before it starts building to later restore to that state. If combined with the `--cleanup` flag it will also restore the state after cleanup.
+If set, kaniko will take a snapshot of the full filesystem before it starts building to later restore to that state. If combined with the `--cleanup` flag it will also restore the state after cleanup. If combined with `--pre-cleanup` it will **not** restore the state in between stages.
 
 This is useful if you want to pass in secrets via files or if you want to execute commands after the build completes.
 
-It will only take the snapshot if we are building a multistage image or if we plan to cleanup the filesystem after the build.
+It will only take the snapshot if we are building a multistage image or if we plan to cleanup the filesystem either before or after the build.
 
 Defaults to `false`
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -258,6 +258,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().IntVarP(&opts.CompressionLevel, "compression-level", "", -1, "Compression level")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cache, "cache", "", false, "Use cache when building image")
 	RootCmd.PersistentFlags().BoolVarP(&opts.CompressedCaching, "compressed-caching", "", true, "Compress the cached layers. Decreases build time, but increases memory usage.")
+	RootCmd.PersistentFlags().BoolVarP(&opts.PreCleanup, "pre-cleanup", "", false, "Clean the filesystem before the build")
 	RootCmd.PersistentFlags().BoolVarP(&opts.Cleanup, "cleanup", "", false, "Clean the filesystem at the end")
 	RootCmd.PersistentFlags().DurationVarP(&opts.CacheTTL, "cache-ttl", "", time.Hour*336, "Cache timeout, requires value and unit of duration -> ex: 6h. Defaults to two weeks.")
 	RootCmd.PersistentFlags().VarP(&opts.InsecureRegistries, "insecure-registry", "", "Insecure registry using plain HTTP to push and pull. Set it repeatedly for multiple registries.")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -84,6 +84,7 @@ type KanikoOptions struct {
 	NoPush                       bool
 	NoPushCache                  bool
 	Cache                        bool
+	PreCleanup                   bool
 	Cleanup                      bool
 	CompressedCaching            bool
 	IgnoreVarRun                 bool


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #189 https://github.com/chainguard-dev/kaniko/issues/76 https://github.com/GoogleContainerTools/kaniko/issues/3407 https://github.com/GoogleContainerTools/kaniko/issues/3339 https://github.com/GoogleContainerTools/kaniko/issues/3321 https://github.com/GoogleContainerTools/kaniko/issues/2177 https://github.com/GoogleContainerTools/kaniko/issues/434 https://github.com/GoogleContainerTools/kaniko/issues/3195 https://github.com/GoogleContainerTools/kaniko/issues/2993 and likely others

**Description**

When building with a customized kaniko image, ie. copying the kaniko executable into a alpine base image, the build environment is not clean from the get-go. As kaniko is building fully within user-space it is paramount to have a clean build environment prior to build or otherwise the snapshotted output might be missing files entirely. So far we recommended to only use the "official" images to not impact build results, but there is a legit use-case for doing some processing prior to building and therefore for customizing the kaniko image.

One simple way to workaround this problem is for kaniko to cleanup the build environment itself prior to build. If we force the filesystem into a clean state we can produce clean images no matter what filesystem we start with. There are some caveats though: First, this cleaning operation will take some additional time and is only necessary if we know that we're running in a polluted image, so most users should not be forced to take the performance penalty for something they don't need. Second, this clashes with the ability of `--preserve-context` to pass secrets into multistage bulids, as we don't know which files are good and should be preserved and which files aren't, so the only safe option is to assume that you don't want any files to be restored in between stages. In general, the only way to pass secrets into any stage with this approach is to add them to the ignore list explicitly `--ignore-path=/root/.secret`. Third, this might not even work depending on how we boot into the customized image, there might be cases where files (like `/bin/sh`) are in active use and hence **undeleteable**.

This said, if users are aware of the limitations of this approach, this can be an easy cop out for supporting custom kaniko images and finally answer their support tickets with something different than, "sorry, this will not work, use buildkit instead".

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
