### PR TITLE
cleanup integration tests

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_1039
+++ b/integration/dockerfiles/Dockerfile_test_issue_1039
@@ -1,11 +1,8 @@
 FROM registry.access.redhat.com/ubi7/ubi:7.7-214 AS base
 
-# Install GCC, GCC-C++ and make libraries for build environment
+# Install make libraries for build environment
 # Then clean caches
-RUN yum --disableplugin=subscription-manager update -y \
-    && yum --disableplugin=subscription-manager install -y \
-        gcc-4.8.5-39.el7 \
-        gcc-c++-4.8.5-39.el7 \
+RUN yum --disableplugin=subscription-manager install -y \
         make-3.82-24.el7 \
     && yum --disableplugin=subscription-manager clean all \
     && rm -rf /var/cache/yum /var/lib/yum/yumdb

--- a/integration/dockerfiles/Dockerfile_test_issue_1039
+++ b/integration/dockerfiles/Dockerfile_test_issue_1039
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi:7.7-214
+FROM registry.access.redhat.com/ubi7/ubi:7.7-214 AS base
 
 # Install GCC, GCC-C++ and make libraries for build environment
 # Then clean caches
@@ -9,3 +9,6 @@ RUN yum --disableplugin=subscription-manager update -y \
         make-3.82-24.el7 \
     && yum --disableplugin=subscription-manager clean all \
     && rm -rf /var/cache/yum /var/lib/yum/yumdb
+
+FROM base
+RUN echo test

--- a/integration/dockerfiles/Dockerfile_test_issue_684
+++ b/integration/dockerfiles/Dockerfile_test_issue_684
@@ -1,7 +1,0 @@
-# ubuntu:bionic-20200219
-FROM ubuntu@sha256:04d48df82c938587820d7b6006f5071dbbffceb7ca01d2814f81857c631d44df as builder
-
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get -y install lib32stdc++6 wget \
-    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

When we looked at which integration-tests take the longest time, these stood out:

1039: was reproducing but never actually grading the result, so it would always pass even on broken code. Now the integration tests works and can reproduce on `v0.17.1`. We were able to simplify it drastically whilst keeping it reproducible.

```
docker run --network=host -v $(pwd):/workspace gcr.io/kaniko-project/executor:v0.17.1   --dockerfile /workspace/integration/dockerfiles/Dockerfile_test_issue_1039 --context dir:///workspace/ --no-push --force
...
INFO[0069] Unpacking rootfs as cmd RUN echo test requires it. 
error building image: error building stage: failed to get filesystem from image: removing whiteout .wh.dev: unl
```

684: was never actually reproducing anything, even in the original issue the maintainers just said that they can't reproduce the issue. So they added that test just for good measure to make sure they don't accidentally cause an issue for something they claimed there is none.

if all goes well that should save us around 2minutes = 20% on integration test time, making development a bit faster going forwards.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
