### PR TITLE
deactivate squashing stages in integration tests again

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -75,7 +75,6 @@ var envsMap = map[string][]string{
 
 var KanikoEnv = []string{
 	"FF_KANIKO_COPY_AS_ROOT=1",
-	"FF_KANIKO_SQUASH_STAGES=1",
 }
 
 // Arguments to build Dockerfiles with when building with docker


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


**Description**

We recently introduced squashing stages and switched all integration tests to it. We switched the integration tests to make sure that this feature works across the board. But what we didn't consider is that some integration tests might now have been altered to no longer test anything effectively. Here I would like to go through all the integration tests that are affected by squashing, of which there shouldn't be many, and see whether what they test for is still being tested correctly if stages are squashed or not.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
