### PR TITLE
whiteout annotations

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -119,6 +119,15 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 		return nil, err
 	}
 
+	man, err := sourceImage.Manifest()
+	if err != nil {
+		return nil, err
+	}
+	ann := map[string]string{}
+	for k := range man.Annotations {
+		ann[k] = ""
+	}
+
 	cf, err := sourceImage.ConfigFile()
 	if err != nil {
 		return nil, err
@@ -131,6 +140,7 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 		return nil, err
 	}
 
+	sourceImageReproducible = mutate.Annotations(sourceImageReproducible, ann).(v1.Image)
 	digest, err := sourceImageReproducible.Digest()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #208 

**Description**

When the annotations on a base image change, our cache gets invalidated completely, even though caches actually only care about layers. We should probably switch at some point to a custom hashing function that only cares for the layers, but for now we still use the image digest.

Anyways, unfortunately there is no provided method for deleting annotations entirely in https://github.com/google/go-containerregistry/blob/main/pkg/v1/mutate/mutate.go and they don't expose the type publicly, contract between grown ups and not children and that and so on... At least they allow you to alter the values, so we can whiteout the annotations, not great not terrible. 
So if you introduce a new annotation key, it will invalidate the caches, but if you just change the value, our whiteout filter will now prevent cache invalidation.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
