### PR TITLE
1713: drop heredoc featureflag

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ expect - see [Known Issues](#known-issues).
     - [Feature Flags](#feature-flags)
       - [Flag `FF_KANIKO_COPY_AS_ROOT`](#flag-ff_kaniko_copy_as_root)
       - [Flag `FF_KANIKO_SQUASH_STAGES`](#flag-ff_kaniko_squash_stages)
-      - [Flag `FF_KANIKO_HEREDOC`](#flag-ff_kaniko_heredoc)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1350,12 +1349,6 @@ Currently no plans to activate.
 
 Many multi-stage Dockerfiles include intermediate stages that only become relevant if we were to build multiple build targets. As kaniko can only build a single target at a time, they can be squashed together without changing the final build output.
 Set this flag to `true` to squash stages together. Defaults to `false`.
-Becomes default in `v1.26.0`.
-
-#### Flag `FF_KANIKO_HEREDOC`
-
-Heredocs, or inline files, is a synctactic sugar in the dockerfile specification. The current implementation is still experimental and might not work in all situations.
-Set this flag to `true` to enable heredoc syntax support. Defaults to `false`.
 Becomes default in `v1.26.0`.
 
 ### Debug Image

--- a/integration/images.go
+++ b/integration/images.go
@@ -75,7 +75,6 @@ var envsMap = map[string][]string{
 
 var KanikoEnv = []string{
 	"FF_KANIKO_COPY_AS_ROOT=1",
-	"FF_KANIKO_HEREDOC=1",
 }
 
 // Arguments to build Dockerfiles with when building with docker

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -225,12 +225,6 @@ func (ca *CachingAddCommand) String() string {
 func addCmdFilesUsedFromContext(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmd *instructions.AddCommand,
 	fileContext util.FileContext,
 ) ([]string, error) {
-	if len(cmd.SourcesAndDest.SourceContents) > 0 && !kConfig.EnvBool("FF_KANIKO_HEREDOC") {
-		// https://github.com/GoogleContainerTools/kaniko/issues/1713
-		logrus.Warnf("#1713 kaniko does not support heredoc syntax in ADD statements: %v", cmd.SourcesAndDest.SourceContents[0].Path)
-		logrus.Info("Experimental syntax support for heredoc can be activated using FF_KANIKO_HEREDOC=1")
-	}
-
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)
 
 	srcs, _, err := util.ResolveEnvAndWildcards(cmd.SourcesAndDest, fileContext, replacementEnvs)

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -139,28 +139,27 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 			c.snapshotFiles = append(c.snapshotFiles, destPath)
 		}
 	}
-	if len(c.cmd.SourcesAndDest.SourceContents) > 0 {
-		if kConfig.EnvBool("FF_KANIKO_HEREDOC") {
-			for _, src := range c.cmd.SourcesAndDest.SourceContents {
-				fullPath := filepath.Join(c.fileContext.Root, src.Path)
-				cwd := config.WorkingDir
-				if cwd == "" {
-					cwd = kConfig.RootDir
-				}
-				destPath, err := util.DestinationFilepath(fullPath, dest, cwd)
-				if err != nil {
-					return errors.Wrap(err, "find destination path")
-				}
 
-				srcFile := strings.NewReader(src.Data)
-				err = util.CreateFile(destPath, srcFile, chmod, uint32(uid), uint32(gid))
-				if err != nil {
-					return errors.Wrap(err, "creating file")
-				}
-				c.snapshotFiles = append(c.snapshotFiles, destPath)
-			}
+	// Heredocs
+	for _, src := range c.cmd.SourcesAndDest.SourceContents {
+		fullPath := filepath.Join(c.fileContext.Root, src.Path)
+		cwd := config.WorkingDir
+		if cwd == "" {
+			cwd = kConfig.RootDir
 		}
+		destPath, err := util.DestinationFilepath(fullPath, dest, cwd)
+		if err != nil {
+			return errors.Wrap(err, "find destination path")
+		}
+
+		srcFile := strings.NewReader(src.Data)
+		err = util.CreateFile(destPath, srcFile, chmod, uint32(uid), uint32(gid))
+		if err != nil {
+			return errors.Wrap(err, "creating file")
+		}
+		c.snapshotFiles = append(c.snapshotFiles, destPath)
 	}
+
 	return nil
 }
 
@@ -312,12 +311,6 @@ func copyCmdFilesUsedFromContext(
 	config *v1.Config, buildArgs *dockerfile.BuildArgs, cmd *instructions.CopyCommand,
 	fileContext util.FileContext,
 ) ([]string, error) {
-	if len(cmd.SourcesAndDest.SourceContents) > 0 && !kConfig.EnvBool("FF_KANIKO_HEREDOC") {
-		// https://github.com/GoogleContainerTools/kaniko/issues/1713
-		logrus.Warnf("#1713 kaniko does not support heredoc syntax in COPY statements: %v", cmd.SourcesAndDest.SourceContents[0].Path)
-		logrus.Info("Experimental syntax support for heredoc can be activated using FF_KANIKO_HEREDOC=1")
-	}
-
 	if cmd.From != "" {
 		fileContext = util.FileContext{Root: filepath.Join(kConfig.KanikoDir, cmd.From)}
 	}

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -64,22 +64,17 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 		}
 
 		cmd := strings.Join(cmdRun.CmdLine, " ")
-		if nfiles := len(cmdRun.Files); nfiles > 0 {
-			if kConfig.EnvBool("FF_KANIKO_HEREDOC") {
-				file0 := cmdRun.Files[0]
-				if nfiles == 1 && cmd == fmt.Sprintf("<<%s", file0.Name) {
-					// 1713: if we encounter a line like 'RUN <<EOF',
-					// we implicitly want the file body to be executed as a script
-					cmd += " sh"
-				}
-				for _, h := range cmdRun.Files {
-					cmd += "\n" + h.Data + h.Name
-				}
-			} else {
-				logrus.Warnf("#1713 kaniko does not support heredoc syntax in 'RUN <command> ...' (Shell Form) statements: %v", cmdRun.Files[0].Name)
-				logrus.Info("Experimental syntax support for heredoc can be activated using FF_KANIKO_HEREDOC=1")
-			}
+
+		// Heredocs
+		if len(cmdRun.Files) == 1 && cmd == fmt.Sprintf("<<%s", cmdRun.Files[0].Name) {
+			// 1713: if we encounter a line like 'RUN <<EOF',
+			// we implicitly want the file body to be executed as a script
+			cmd += " sh"
 		}
+		for _, h := range cmdRun.Files {
+			cmd += "\n" + h.Data + h.Name
+		}
+
 		newCommand = append(shell, cmd)
 	} else {
 		if len(cmdRun.Files) > 0 {

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -92,9 +92,6 @@ func ResolveEnvAndWildcards(sd instructions.SourcesAndDest, fileContext FileCont
 	if err != nil {
 		return nil, "", errors.Wrap(err, "failed to resolve environment")
 	}
-	if len(resolvedEnvs) == 0 && !config.EnvBool("FF_KANIKO_HEREDOC") {
-		return nil, "", errors.New("resolved envs is empty")
-	}
 	dests, err := ResolveEnvironmentReplacementList([]string{sd.DestPath}, envs, true)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "failed to resolve environment for dest path")
@@ -285,11 +282,6 @@ func IsSrcsValid(srcsAndDest instructions.SourcesAndDest, resolvedSources []stri
 			}
 			totalFiles++
 		}
-	}
-	// ignore the case where whildcards and there are no files to copy
-	if totalFiles == 0 && !config.EnvBool("FF_KANIKO_HEREDOC") {
-		// using log warning instead of return errors.New("copy failed: no source files specified")
-		logrus.Warn("No files to copy")
 	}
 	// If there are wildcards, and the destination is a file, there must be exactly one file to copy over,
 	// Otherwise, return an error


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

We actually do nothing dangerous to dockerfiles that don't contain heredocs and we provide better UX for dockerfiles that do contain them. So in any case it is better to make this feature enabled by default, there is no point in hiding it behind a feature flag.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
