### PR TITLE
3369: add docs for azure chinacloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,13 @@ identities and the MSI endpoint is attempted to be contacted which will work in
 various Azure contexts such as App Service and Azure Kubernetes Service where
 the MSI endpoint will authenticate the MSI context the service is running under.
 
+`AZURE_ENVIRONMENT=<environment>` can be used to connect to clouds other than the standard public cloud.
+Choose among:
+  * `AZUREPUBLICCLOUD` (default)
+  * `AZURECHINACLOUD`
+  * `AZUREGERMANCLOUD`
+  * `AZUREUSGOVERNMENT`
+
 The Kubernetes Pod spec should look similar to this, with the args parameters
 filled in. Note that `azure-secret` secret is only needed when using Azure
 Service Principal credentials, not when using a managed service identity.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/GoogleContainerTools/kaniko/issues/3369

**Description**

Honestly I haven't tested whether this setting actually works for azure china cloud, as it would require me to do the whole account setup and everything, but based on reading the [code in the dependency](https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L33) this is how you can configure access to clouds other than the public cloud. If you can verify/refute this, feedback would be much appreciated, thank you.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
