### PR TITLE
 Adjust the determination priority of runtime under the Kubernetes cluster with cgroupv2

### DIFF
--- a/pkg/util/proc/proc.go
+++ b/pkg/util/proc/proc.go
@@ -78,6 +78,12 @@ var (
 // GetContainerRuntime returns the container runtime the process is running in.
 // If pid is less than one, it returns the runtime for "self".
 func GetContainerRuntime(tgid, pid int) ContainerRuntime {
+	// Check for container specific files
+	runtime := detectContainerFiles()
+	if runtime != RuntimeNotFound {
+		return runtime
+	}
+
 	file := "/proc/self/cgroup"
 	if pid > 0 {
 		if tgid > 0 {
@@ -89,7 +95,7 @@ func GetContainerRuntime(tgid, pid int) ContainerRuntime {
 
 	// read the cgroups file
 	a := readFileString(file)
-	runtime := getContainerRuntime(a)
+	runtime = getContainerRuntime(a)
 	if runtime != RuntimeNotFound {
 		return runtime
 	}
@@ -130,12 +136,6 @@ func GetContainerRuntime(tgid, pid int) ContainerRuntime {
 	// which needs CAP_SYS_PTRACE
 	a = readFileString("/run/systemd/container")
 	runtime = getContainerRuntime(a)
-	if runtime != RuntimeNotFound {
-		return runtime
-	}
-
-	// Check for container specific files
-	runtime = detectContainerFiles()
 	if runtime != RuntimeNotFound {
 		return runtime
 	}

--- a/pkg/util/proc/proc_test.go
+++ b/pkg/util/proc/proc_test.go
@@ -125,6 +125,10 @@ func TestGetContainerRuntime(t *testing.T) {
 2:perf_event:/
 1:name=systemd:/machine.slice/machine-rkt\x2dbfb7d57e\x2d80ff\x2d4ef8\x2db602\x2d9b907b3f3a38.scope/system.slice/debian.service`,
 		},
+		"cgroup v2": {
+			expectedRuntime: RuntimeNotFound,
+			input:           `0::/`,
+		},
 	}
 
 	for key, tc := range testcases {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Copied from https://github.com/chainguard-dev/kaniko/pull/153

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
