### PR TITLE
247: avoid skipping siblings if /var/run is a soft-link

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz247
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz247
@@ -1,0 +1,22 @@
+FROM busybox AS base
+
+# mz247: Starting with v1.25.3 we introduced a regression
+# in this PR https://github.com/mzihlmann/kaniko/pull/180
+# karrick/godirwalk would recurse into symlinks, therefore returning SkipDir from inside
+# a directory opened via symlink would only skip that directory. But fs.WalkDir does not
+# recurse into symlinks, it treats symlinks as regular files, not directories. Returning
+# SkipDir when processing a file means skip the rest of the current directory, skip siblings.
+# This behaviour can be observed when systemd is installed because systemd replaces /var/run
+# with a symlink to /var/run -> /run. However, /var/run is ignored by default.
+RUN mkdir /run \
+    && ln -s /run /var/run
+
+# As it is now a symlink, we don't snapshot any files or directories
+# that come later alphabetically. Our /var/www happens to be skipped accidentally.
+RUN mkdir -p /var/www
+
+# This can be seen easily when building a multistage image, as we load the image
+# from the snapshots, dropping all files/folders that were just lying around.
+FROM base
+RUN ls -la /var \
+    && test -d /var/www

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -1233,14 +1233,14 @@ func gowalkDir(dir string, existingPaths map[string]struct{}, changeFunc func(st
 	foundPaths := make([]string, 0)
 	deletedFiles := existingPaths // Make a reference.
 
-	callback := func(path string, _ fs.DirEntry, err error) error {
+	callback := func(path string, info fs.DirEntry, err error) error {
 		logrus.Tracef("Analyzing path '%s'", path)
 		if err != nil {
 			return err
 		}
 
 		if IsInIgnoreList(path) {
-			if IsDestDir(path) {
+			if IsDestDir(path) && info.IsDir() {
 				logrus.Tracef("Skipping paths under '%s', as it is an ignored directory", path)
 				return filepath.SkipDir
 			}
@@ -1272,12 +1272,12 @@ func GetFSInfoMap(dir string, existing map[string]os.FileInfo) (map[string]os.Fi
 	fileMap := map[string]os.FileInfo{}
 	foundPaths := []string{}
 	timer := timing.Start("Walking filesystem with Stat")
-	callback := func(path string, _ fs.DirEntry, err error) error {
+	callback := func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if CheckCleanedPathAgainstIgnoreList(path) {
-			if IsDestDir(path) {
+			if IsDestDir(path) && info.IsDir() {
 				logrus.Tracef("Skipping paths under %s, as it is a ignored directory", path)
 				return filepath.SkipDir
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/mzihlmann/kaniko/issues/247

**Description**

Starting with **v1.25.3** we introduced a regression in this PR https://github.com/mzihlmann/kaniko/pull/180
In that PR we swapped out the deprecated **karrick/godirwalk** for the new stdlib implementation **fs.WalkDir**, as it allows us to provide our own filesystem interface, which we can use to not bump `atime` on snapshotting, which was the major feature in the v1.25.3 release. It is also reported to be faster and removing a dependency, especially unmaintained ones, is always a win. In principle both functions do the same, they recursively run through a directory, whether they continue or not can be controlled by returning `SkipDir`. Returning `SkipDir` when opening a folder, means skip that current folder and all it's children. When calling `SkipDir` on a file, it means skip that file and all it's siblings. So far so good.

However, their behaviour is substantially different, `karrick/godirwalk` would recurse into symlinks, therefore returning `SkipDir` from inside a directory opened via symlink would only skip that directory. But `fs.WalkDir` does **not** recurse into symlinks, it treats symlinks as regular files, not directories, therefore returning `SkipDir` when looking at a symlink will skip the symlink **and all its siblings**.

This behaviour can be observed when systemd is installed because systemd replaces `/var/run` with a symlink to `/var/run -> /run`.  `/var/run` is ignored by default as per the weird cli setting `--ignore-var-run=true`. As it is now a symlink, we don't snapshot any files or directories that come later alphabetically. Our `/var/www` therefore happens to be skipped as a consequence.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
