### PR TITLE
cg159: parse metaArgs in warmer

### DIFF
--- a/pkg/cache/warm.go
+++ b/pkg/cache/warm.go
@@ -201,13 +201,19 @@ func ParseDockerfile(opts *config.WarmerOptions) ([]string, error) {
 		return nil, errors.Wrap(err, fmt.Sprintf("reading dockerfile at path %s", opts.DockerfilePath))
 	}
 
-	stages, _, err := dockerfile.Parse(d)
+	stages, metaArgs, err := dockerfile.Parse(d)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing dockerfile")
 	}
 
+	args := opts.BuildArgs
+	for _, marg := range metaArgs {
+		for _, arg := range marg.Args {
+			args = append(args, fmt.Sprintf("%s=%s", arg.Key, arg.ValueString()))
+		}
+	}
 	for i, s := range stages {
-		resolvedBaseName, err := util.ResolveEnvironmentReplacement(s.BaseName, opts.BuildArgs, false)
+		resolvedBaseName, err := util.ResolveEnvironmentReplacement(s.BaseName, args, false)
 		if err != nil {
 			return nil, errors.Wrap(err, fmt.Sprintf("resolving base name %s", s.BaseName))
 		}

--- a/pkg/cache/warm_test.go
+++ b/pkg/cache/warm_test.go
@@ -182,8 +182,8 @@ LABEL maintainer="alexezio"
 }
 
 func TestParseDockerfile_ArgsDockerfile(t *testing.T) {
-	dockerfile := `ARG version=latest
-FROM golang:${version}
+	dockerfile := `ARG NGINX_VERSION=1.29.1
+FROM nginx:$NGINX_VERSION-alpine-slim
 `
 	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
@@ -206,8 +206,8 @@ FROM golang:${version}
 	if len(baseNames) != 1 {
 		t.Fatalf("expected 1 base name, got %d", len(baseNames))
 	}
-	if baseNames[0] != "golang:1.20" {
-		t.Fatalf("expected 'golang:1.20', got '%s'", baseNames[0])
+	if baseNames[0] != "nginx:1.29.1-alpine-slim" {
+		t.Fatalf("expected 'nginx:1.29.1-alpine-slim', got '%s'", baseNames[0])
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/chainguard-dev/kaniko/issues/159

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
