### PR TITLE
mz305: skip-unused-stages invalidates numeric references

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz305
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz305
@@ -1,0 +1,11 @@
+FROM busybox AS zero
+FROM busybox AS one
+RUN touch /tmp/blubb
+FROM busybox AS two
+# mz305: build fails in kaniko v1.25.6 and priors.
+# --skip-unused-stages can drop stages, and we refer to them by the list index in code.
+# However, in the commands themselves the indizes are never updated.
+# In this specific edge-case the simplified list will be `[one, two]`,
+# so index `1` erronously points to stage `two`, a self-reference.
+COPY --from=1 /tmp /tmp
+RUN ls -la /tmp


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/305

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
