### PR TITLE
mz308: enable FF_KANIKO_SQUASH_STAGES in integrationtests

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -69,9 +69,16 @@ var argsMap = map[string][]string{
 
 // Environment to build Dockerfiles with, used for both docker and kaniko builds
 var envsMap = map[string][]string{
-	"Dockerfile_test_arg_secret":  {"SSH_PRIVATE_KEY=ThEPriv4t3Key"},
-	"Dockerfile_test_issue_519":   {"DOCKER_BUILDKIT=0"},
-	"Dockerfile_test_issue_mz282": {"FF_KANIKO_SQUASH_STAGES=1"},
+	"Dockerfile_test_arg_secret":                 {"SSH_PRIVATE_KEY=ThEPriv4t3Key"},
+	"Dockerfile_test_issue_519":                  {"DOCKER_BUILDKIT=0", "FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_cmd":                        {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_mz247":                {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_multistage_args_issue_1911": {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_mz276":                {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_pre_defined_build_args":     {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_1039":                 {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_2066":                 {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_1837":                 {"FF_KANIKO_SQUASH_STAGES=0"},
 }
 
 var KanikoEnv = []string{
@@ -79,6 +86,7 @@ var KanikoEnv = []string{
 	"FF_KANIKO_RUN_MOUNT_CACHE=1",
 	"FF_KANIKO_NEW_CACHE_LAYOUT=1",
 	"FF_KANIKO_OCI_STAGES=1",
+	"FF_KANIKO_SQUASH_STAGES=1",
 }
 
 // Arguments to build Dockerfiles with when building with docker
@@ -102,6 +110,9 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_cache_copy":             {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache_copy_oci":         {"--cache-copy-layers=true"},
 	"Dockerfile_test_issue_add":              {"--cache-copy-layers=true"},
+	"Dockerfile_test_volume_3":               {"--skip-unused-stages=false"},
+	"Dockerfile_test_multistage":             {"--skip-unused-stages=false"},
+	"Dockerfile_test_copy_root_multistage":   {"--skip-unused-stages=false"},
 }
 
 // Arguments to diffoci when comparing dockerfiles
@@ -559,13 +570,13 @@ func buildKanikoImage(
 		"-v", benchmarkDir + ":/kaniko/benchmarks",
 	}
 
+	for _, envVariable := range KanikoEnv {
+		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
+	}
 	if env, ok := envsMap[dockerfile]; ok {
 		for _, envVariable := range env {
 			dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 		}
-	}
-	for _, envVariable := range KanikoEnv {
-		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
 
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/308

**Description**

Before we make [FF_KANIKO_SQUASH_STAGES](https://github.com/osscontainertools/kaniko#flag-ff_kaniko_squash_stages) default in `v1.26.0` (planned 16.10.2025) we need to make sure that all the integrationtests remain meaningful under that new optimization. Some integrationtests test that files remain consistent when switching between stages. ie. This test tests that capabilities are correctly copied over when switching between stages.
```dockerfile
# integration/dockerfiles/Dockerfile_test_issue_1837
FROM registry.access.redhat.com/ubi8/ubi:8.2 AS base
# Install ping
RUN dnf install -y iputils \
    && dnf clean all \
    && rm -rf /var/cache/dnf /var/log/dnf* /var/log/rhsm

RUN setcap cap_net_raw+ep /bin/ping || exit 1

FROM base
RUN [ ! -z "$(getcap /bin/ping)" ] || exit 1
```
If we were to squash the stages together into one, they would become completely meaningless as the dockerfile internally get's turned into this

```dockerfile
# integration/dockerfiles/Dockerfile_test_issue_1837 - squashed
FROM registry.access.redhat.com/ubi8/ubi:8.2
# Install ping
RUN dnf install -y iputils \
    && dnf clean all \
    && rm -rf /var/cache/dnf /var/log/dnf* /var/log/rhsm

RUN setcap cap_net_raw+ep /bin/ping || exit 1
RUN [ ! -z "$(getcap /bin/ping)" ] || exit 1
```


 Long-term we should rewrite them to work despite squashing, but for now it's enough if we just deactivate squashing for them explicitly. 

The same is true for skipping, just that for skipping we didn't catch that when we activated it default in `v1.25.0`, so here I add exceptions for those too retroactively.

I found all tests that are impacted by skipping and squashing by adding a warning when one of the actions occur, the integration tests are written to fail when a warning is in the job log. Of course before merge I had to remove that again as we don't want that warning to happen in production.

Some of the tests do explictly test for squashing and skipping, so they should not be deactivated in this way.



**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
