### PR TITLE
mz308: activate featureflags for v1.26.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1388,8 +1388,9 @@ Currently no plans to activate.
 #### Flag `FF_KANIKO_SQUASH_STAGES`
 
 Many multi-stage Dockerfiles include intermediate stages that only become relevant if we were to build multiple build targets. As kaniko can only build a single target at a time, they can be squashed together without changing the final build output.
-Set this flag to `true` to squash stages together. Defaults to `false`.
-Becomes default in `v1.26.0`.
+Set this flag to `true` to squash stages together.
+Defaults to `true`.
+Will be deprecated in `v1.27.0`.
 
 #### Flag `FF_KANIKO_IGNORE_CACHED_MANIFEST`
 
@@ -1406,22 +1407,22 @@ RUN --mount=type=cache,target=/var/lib/apt/lists/ \
   apt-get update \
   && apt-get -y install cowsay
 ```
-Defaults to `false`.
-Becomes default in `v1.26.0`.
+Defaults to `true`.
+Will be deprecated in `v1.27.0`.
 
 #### Flag `FF_KANIKO_NEW_CACHE_LAYOUT`
 
 Kaniko stores cache-layers and inter-stage dependencies in `/kaniko` folder directly. Our plan is to make downloaded cache-layers shareable on the host, similar to images downloaded with warmer. Therefore we should move them to a subdirectory, s.t. they can later be replaced with a volume mount.
 Set this flag to `true` to store cache-layers in `/kaniko/layers` and inter-stage dependencies in `/kaniko/deps` respectively.
-Defaults to `false`.
-Becomes default in `v1.26.0`.
+Defaults to `true`.
+Will be deprecated in `v1.27.0`.
 
 #### Flag `FF_KANIKO_OCI_STAGES`
 
 To switch between stages Kaniko has to store in a local directory temporarily. So far this is done using tarballs from go-containerregistry. However, this approach creates two problems. The tarball writer only supports dockerv2 mediatype, so when building a multi-stage image we forcefully rewrite all images to that mediatype. Secondly, the performance of that approach is suboptimal, as the manifest is not stored and has to be recalculated (ie. digest hash) upon reload. With this change we use ocilayout instead. Ocilayout folders support arbitrary mediatypes and store the manifest alongside the image data.
 Set this flag to `true` to store inter-stage dependencies as ocilayout.
 Defaults to `false`.
-Becomes default in `v1.26.0`.
+Becomes default in `v1.27.0`.
 
 ### Debug Image
 

--- a/integration/images.go
+++ b/integration/images.go
@@ -83,10 +83,7 @@ var envsMap = map[string][]string{
 
 var KanikoEnv = []string{
 	"FF_KANIKO_COPY_AS_ROOT=1",
-	"FF_KANIKO_RUN_MOUNT_CACHE=1",
-	"FF_KANIKO_NEW_CACHE_LAYOUT=1",
 	"FF_KANIKO_OCI_STAGES=1",
-	"FF_KANIKO_SQUASH_STAGES=1",
 }
 
 // Arguments to build Dockerfiles with when building with docker

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -56,7 +56,7 @@ func (r *RunCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 }
 
 func runCommandWithFlags(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun *instructions.RunCommand) (reterr error) {
-	ff_cache := kConfig.EnvBool("FF_KANIKO_RUN_MOUNT_CACHE")
+	ff_cache := kConfig.EnvBoolDefault("FF_KANIKO_RUN_MOUNT_CACHE", true)
 	for _, f := range cmdRun.FlagsUsed {
 		if !(ff_cache && f == "mount") {
 			logrus.Warnf("#969 kaniko does not support '--%s' flags in RUN statements - relying on unsupported flags can lead to invalid builds", f)

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -47,7 +47,7 @@ var KanikoIntermediateStagesDir = fmt.Sprintf("%s/stages/", KanikoDir)
 // KanikoInsterStageDir is where we will store inter-stage dependencies
 // Contents are stored as-is.
 var KanikoInterStageDepsDir = func() string {
-	if EnvBool("FF_KANIKO_NEW_CACHE_LAYOUT") {
+	if EnvBoolDefault("FF_KANIKO_NEW_CACHE_LAYOUT", true) {
 		return fmt.Sprintf("%s/deps/", KanikoDir)
 	}
 	return KanikoDir
@@ -55,7 +55,7 @@ var KanikoInterStageDepsDir = func() string {
 
 // KanikoLayersDir is where we will store layers as tarballs
 var KanikoLayersDir = func() string {
-	if EnvBool("FF_KANIKO_NEW_CACHE_LAYOUT") {
+	if EnvBoolDefault("FF_KANIKO_NEW_CACHE_LAYOUT", true) {
 		return fmt.Sprintf("%s/layers/", KanikoDir)
 	}
 	return KanikoDir

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -192,7 +192,17 @@ type WarmerOptions struct {
 }
 
 func EnvBool(key string) bool {
-	val := os.Getenv(key)
+	return EnvBoolDefault(key, false)
+}
+
+func EnvBoolDefault(key string, def bool) bool {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
 	ok, err := strconv.ParseBool(val)
-	return err == nil && ok
+	if err != nil {
+		return def
+	}
+	return ok
 }

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -302,7 +302,7 @@ func MakeKanikoStages(opts *config.KanikoOptions, stages []instructions.Stage, m
 		}
 	}
 	if opts.SkipUnusedStages {
-		ffSquashStages := config.EnvBool("FF_KANIKO_SQUASH_STAGES")
+		ffSquashStages := config.EnvBoolDefault("FF_KANIKO_SQUASH_STAGES", true)
 		kanikoStages = skipUnusedStages(kanikoStages, targetStage, ffSquashStages)
 	}
 	return kanikoStages, nil


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/308

**Description**

Activate featureflags in preperation of v1.26.0 release:

* [FF_KANIKO_SQUASH_STAGES](https://github.com/osscontainertools/kaniko#flag-ff_kaniko_squash_stages)
A major performance improvement that was risky at first, but now the bugs *should* all be ironed out. So I would deem it low risk to activate now.

* [FF_KANIKO_RUN_MOUNT_CACHE](https://github.com/osscontainertools/kaniko#flag-ff_kaniko_run_mount_cache)
A new feature that is hardly tested, so the risk is pretty high, but expectation in community for this feature seems pretty high. So neither waiting not activating are really good options. I think we should activate it now and just expect bug fixes in v1.26.1 for it, but I'm on the fence about it.

* [FF_KANIKO_NEW_CACHE_LAYOUT](https://github.com/osscontainertools/kaniko#flag-ff_kaniko_new_cache_layout)
Very low risk, no benefit per-se, it is an enabler for other features/workflows down the line.

* [FF_KANIKO_OCI_STAGES](https://github.com/osscontainertools/kaniko#flag-ff_kaniko_oci_stages)
Medium risk, yields a small performance benefit, only tested in integration tests here, not in production. resolves some issues with weird behaviour around oci compatibility. I'm a bit on the fence about this one. Maybe we should wait with this one.