### PR TITLE
warmer-cache and layer-cache are two distinct concepts

### DIFF
--- a/pkg/image/image_util.go
+++ b/pkg/image/image_util.go
@@ -76,7 +76,7 @@ func RetrieveSourceImage(stage config.KanikoStage, opts *config.KanikoOptions) (
 
 	// Finally, check if local caching is enabled
 	// If so, look in the local cache before trying the remote registry
-	if opts.Cache && opts.CacheDir != "" {
+	if opts.CacheDir != "" {
 		cachedImage, err := cachedImage(opts, currentBaseName)
 		if err != nil {
 			switch {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

As the PR title says, warmer-cache (where we pre-fetch the images) and layer-cache (where we skip run steps) are two distinct concepts and you should be allowed to have one without the other. Making warmer-cache dependent on layer-cache leads to this awkward situation for when you want to build in a airgapped environment, you have to pass:
```shell
--cache-dir /cache --cache --no-push-cache
```
Basically saying I would like to build from warmer, but I don't care about layer-cache. Even worse, this causes performance to drop, because even if you don't push the layer cache, the snapshots will be created.
With this change you can now just say:
```
--cache-dir /cache
```
And the builder will try to leverage pre-fetched images.

Even though this will change the interface slightly. I think noone should be affected adversely as it was so far impossible to use warmer-cache without layer-cache. So, I see no need to feature-flag this change.