### PR TITLE
mz334: stageIdx is an int

### DIFF
--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -249,13 +249,13 @@ func saveStage(index int, stages []instructions.Stage) bool {
 // ResolveCrossStageCommands resolves any calls to previous stages with names to indices
 // Ex. --from=secondStage should be --from=1 for easier processing later on
 // As third party library lowers stage name in FROM instruction, this function resolves stage case insensitively.
-func ResolveCrossStageCommands(cmds []instructions.Command, stageNameToIdx map[string]string) {
+func ResolveCrossStageCommands(cmds []instructions.Command, stageNameToIdx map[string]int) {
 	for _, cmd := range cmds {
 		switch c := cmd.(type) {
 		case *instructions.CopyCommand:
 			if c.From != "" {
 				if val, ok := stageNameToIdx[strings.ToLower(c.From)]; ok {
-					c.From = val
+					c.From = strconv.Itoa(val)
 				}
 			}
 		}
@@ -323,7 +323,7 @@ func MakeKanikoStages(opts *config.KanikoOptions, stages []instructions.Stage, m
 	return kanikoStages, nil
 }
 
-func GetOnBuildInstructions(config *v1.Config, stageNameToIdx map[string]string) ([]instructions.Command, error) {
+func GetOnBuildInstructions(config *v1.Config, stageNameToIdx map[string]int) ([]instructions.Command, error) {
 	if config.OnBuild == nil || len(config.OnBuild) == 0 {
 		return nil, nil
 	}

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -196,24 +196,24 @@ func Test_GetOnBuildInstructions(t *testing.T) {
 	type testCase struct {
 		name        string
 		cfg         *v1.Config
-		stageToIdx  map[string]string
+		stageToIdx  map[string]int
 		expCommands []instructions.Command
 	}
 
 	tests := []testCase{
 		{name: "no on-build on config",
 			cfg:         &v1.Config{},
-			stageToIdx:  map[string]string{"builder": "0"},
+			stageToIdx:  map[string]int{"builder": 0},
 			expCommands: nil,
 		},
 		{name: "onBuild on config, nothing to resolve",
 			cfg:         &v1.Config{OnBuild: []string{"WORKDIR /app"}},
-			stageToIdx:  map[string]string{"builder": "0", "temp": "1"},
+			stageToIdx:  map[string]int{"builder": 0, "temp": 1},
 			expCommands: []instructions.Command{&instructions.WorkdirCommand{Path: "/app"}},
 		},
 		{name: "onBuild on config, resolve multiple stages",
 			cfg:        &v1.Config{OnBuild: []string{"COPY --from=builder a.txt b.txt", "COPY --from=temp /app /app"}},
-			stageToIdx: map[string]string{"builder": "0", "temp": "1"},
+			stageToIdx: map[string]int{"builder": 0, "temp": 1},
 			expCommands: []instructions.Command{
 				&instructions.CopyCommand{
 					SourcesAndDest: instructions.SourcesAndDest{SourcePaths: []string{"a.txt"}, DestPath: "b.txt"},

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -1667,8 +1667,8 @@ func Test_stageBuild_populateCompositeKeyForCopyCommand(t *testing.T) {
 
 					sb := &stageBuilder{
 						fileContext: fc,
-						stageIdxToDigest: map[string]string{
-							"0": "some-digest",
+						stageIdxToDigest: map[int]string{
+							0: "some-digest",
 						},
 						digestToCacheKey: map[string]string{
 							"some-digest": "some-cache-key",
@@ -1741,7 +1741,7 @@ func Test_ResolveCrossStageInstructions(t *testing.T) {
 			}
 		}
 
-		expectedMap := map[string]string{"second": "1", "third": "2"}
+		expectedMap := map[string]int{"second": 1, "third": 2}
 		testutil.CheckDeepEqual(t, expectedMap, stageToIdx)
 	}
 }
@@ -1760,7 +1760,7 @@ func Test_stageBuilder_saveSnapshotToLayer(t *testing.T) {
 		args             *dockerfile.BuildArgs
 		crossStageDeps   map[int][]string
 		digestToCacheKey map[string]string
-		stageIdxToDigest map[string]string
+		stageIdxToDigest map[int]string
 		snapshotter      snapShotter
 		layerCache       cache.LayerCache
 		pushLayerToCache cachePusher
@@ -1890,7 +1890,7 @@ func Test_stageBuilder_convertLayerMediaType(t *testing.T) {
 		args             *dockerfile.BuildArgs
 		crossStageDeps   map[int][]string
 		digestToCacheKey map[string]string
-		stageIdxToDigest map[string]string
+		stageIdxToDigest map[int]string
 		snapshotter      snapShotter
 		layerCache       cache.LayerCache
 		pushLayerToCache cachePusher


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This is a refactoring in preparation for https://github.com/osscontainertools/kaniko/issues/334

**Description**

Pretty simple, stageIdx is an `int` and not a `string`, that's all.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
