### PR TITLE
mz334: move resolveCrossStageCommands forwards

### DIFF
--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -235,7 +235,7 @@ func Test_GetOnBuildInstructions(t *testing.T) {
 			if len(cmds) != len(test.expCommands) {
 				t.Fatalf("Expected %d commands, got %d", len(test.expCommands), len(cmds))
 			}
-			ResolveCrossStageCommands(cmds, test.stageToIdx)
+			resolveCrossStageCommands(cmds, test.stageToIdx)
 
 			for i, cmd := range cmds {
 				if reflect.TypeOf(cmd) != reflect.TypeOf(test.expCommands[i]) {


### PR DESCRIPTION
This is a refactoring in preparation for https://github.com/osscontainertools/kaniko/issues/334

**Description**

When we create KanikoStage's we replace all baseImage references with numeric references. But we keep both named and numeric references in `COPY --from`. ie `COPY --from=base` or `COPY --from=0` (yes this is valid syntax). Later we replace those references a bit hidden as part of `ResolveCrossStageInstructions`. With this change we just move that transformation to the beginning, so when you have a KanikoStage you are guaranteed to only have numeric references to other stages.