### PR TITLE
mz316: stop forcing http/2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_RUN_MOUNT_CACHE`](#flag-ff_kaniko_run_mount_cache)
       - [Flag `FF_KANIKO_NEW_CACHE_LAYOUT`](#flag-ff_kaniko_new_cache_layout)
       - [Flag `FF_KANIKO_OCI_STAGES`](#flag-ff_kaniko_oci_stages)
+      - [Flag `FF_KANIKO_DISABLE_HTTP2`](#flag-ff_kaniko_disable_http2)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1351,6 +1352,12 @@ To switch between stages Kaniko has to store in a local directory temporarily. S
 Set this flag to `true` to store inter-stage dependencies as ocilayout.
 Defaults to `false`.
 Becomes default in `v1.27.0`.
+
+#### Flag `FF_KANIKO_DISABLE_HTTP2`
+
+We noticed that there is a significant performance gap when using http/2.0 together with gitlab registry. Set this flag to `true` to enforce http/1.1 protocol, the same behaviour as if setting `GODEBUG="http2client=0"`.
+Defaults to `false`.
+Currently no plans to activate.
 
 ### Debug Image
 

--- a/pkg/util/transport_util.go
+++ b/pkg/util/transport_util.go
@@ -107,5 +107,10 @@ func MakeTransport(opts config.RegistryOptions, registryName string) (http.Round
 		tr.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{cert}
 	}
 
+	if config.EnvBool("FF_KANIKO_DISABLE_HTTP2") {
+		tr.(*http.Transport).ForceAttemptHTTP2 = false
+		tr.(*http.Transport).TLSClientConfig.NextProtos = []string{"http/1.1"}
+	}
+
 	return tr, nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


fixes https://github.com/osscontainertools/kaniko/issues/316

**Description**

We found that go stdlibs behaviour of attempting to force http/2.0 connection causes significant performance hit when communicating with gitlab registry. gitlab registry only talks http/1.1 on the data path but can talk http/2.0 on the auth path, somehow this causes performance hit, likely due to many roundtrips until protocol is settled.

There is an existing feature-flag in the stdlib, here we just hoist that featureflag into a kaniko featureflag, to make the setting better discoverable for users.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
