### PR TITLE
mz342: fix copy capabilities

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -1091,17 +1091,14 @@ func CopyOwnership(src string, destDir string, root string) error {
 
 // CopyCapabilities copies the file capabilities from src to dest
 func CopyCapabilities(src string, dest string) error {
-	capBuf := make([]byte, 1024)
-	n, err := unix.Getxattr(src, "security.capability", capBuf)
-	if err == syscall.ENODATA {
-		return nil
-	} else if err != nil {
-		return errors.Wrap(err, "getting security.capability from src")
+	caps, err := Lgetxattr(src, securityCapabilityXattr)
+	if err != nil {
+		return errors.Wrapf(err, "getting %q from src", securityCapabilityXattr)
 	}
-	if n > 0 {
-		err = unix.Setxattr(dest, "security.capability", capBuf[:n], 0)
+	if caps != nil {
+		err = Lsetxattr(dest, securityCapabilityXattr, caps, 0)
 		if err != nil {
-			return errors.Wrap(err, "setting security.capability on dest")
+			return errors.Wrapf(err, "setting %q on dest", securityCapabilityXattr)
 		}
 	}
 	return nil

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -34,8 +34,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var ErrNotSupportedPlatform = errors.New("platform and architecture is not supported")
-
 // Tar knows how to write files to a tar file.
 type Tar struct {
 	hardlinks map[uint64]string
@@ -144,10 +142,6 @@ func (t *Tar) AddFileToTar(p string) error {
 	return nil
 }
 
-const (
-	securityCapabilityXattr = "security.capability"
-)
-
 // writeSecurityXattrToTarFile writes security.capability
 // xattrs from a tar header to filesystem
 func writeSecurityXattrToTarFile(path string, hdr *tar.Header) error {
@@ -170,7 +164,7 @@ func readSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
 		hdr.Xattrs = make(map[string]string)
 	}
 	capability, err := Lgetxattr(path, securityCapabilityXattr)
-	if err != nil && !errors.Is(err, syscall.EOPNOTSUPP) && !errors.Is(err, ErrNotSupportedPlatform) {
+	if err != nil {
 		return errors.Wrapf(err, "failed to read %q attribute from %q", securityCapabilityXattr, path)
 	}
 	if capability != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -35,6 +35,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var ErrNotSupportedPlatform = errors.New("platform and architecture is not supported")
+
+const (
+	securityCapabilityXattr = "security.capability"
+)
+
 // Hasher returns a hash function, used in snapshotting to determine if a file has changed
 func Hasher() func(string) (string, error) {
 	pool := sync.Pool{
@@ -233,7 +239,9 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 	}
 
 	switch {
-	case errors.Is(errno, unix.ENODATA):
+	case errors.Is(errno, unix.ENODATA),
+		errors.Is(errno, syscall.EOPNOTSUPP),
+		errors.Is(errno, ErrNotSupportedPlatform):
 		return nil, nil
 	case errno != nil:
 		return nil, errno


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/342

**Description**

Our implementation of copy capabilities introduced in https://github.com/osscontainertools/kaniko/pull/107 had several glaring issues

* no handling for systems without support `syscall.EOPNOTSUPP`
* no handling for cases buffer is too small `unix.ERANGE`
* no handling for links `Lgetxattr/Lsetxattr` over `Getxattr/Setxattr`

These were uncovered when building with context on an NFS filesystem. NFS raises `syscall.EOPNOTSUPP` as it doesn't support xattrs on file metadata. We dogfeed our `CopyFile` function, which is used to copy files around between stages with special care to preserve the metadata, to copy the `Dockerfile` from context, which is actually overkill as no-one cares about timestamps on the dockerfile, but whatever.

Those were all handled correctly in the original tiny wrapper `util.Lgetxattr` introduced way back when. So we now we just switch to using this wrapper instead and fix the issue raised. For convenience I moved some of the error handling down into the wrapper, also fine to me if error handling is on the caller's end.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
