### PR TITLE
use upstream images from local registry

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_extraction
+++ b/integration/dockerfiles/Dockerfile_test_extraction
@@ -1,2 +1,3 @@
 # Tests extraction of symlink, hardlink and regular files to a path that is a non-empty directory
-FROM gcr.io/kaniko-test/extraction-base-image:latest
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}extraction-base-image:latest

--- a/integration/dockerfiles/Dockerfile_test_hardlink
+++ b/integration/dockerfiles/Dockerfile_test_hardlink
@@ -1,3 +1,4 @@
+ARG IMAGE_REPO
 FROM composer@sha256:4598feb4b58b4370893a29cbc654afa9420b4debed1d574531514b78a24cd608 AS composer
 FROM php@sha256:13813f20fec7ded7bf3a4305ea0ccd4df3cea900e263f7f86c3d5737f86669eb
 COPY --from=composer /usr/bin/composer /usr/bin/composer
@@ -5,7 +6,7 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 # make sure hardlink extracts correctly
 FROM jboss/base-jdk@sha256:138591422fdab93a5844c13f6cbcc685631b37a16503675e9f340d2503617a41
 
-FROM gcr.io/kaniko-test/hardlink-base:latest
+FROM ${IMAGE_REPO}hardlink-base:latest
 RUN ls -al /usr/libexec/git-core/git /usr/bin/git /usr/libexec/git-core/git-diff
 RUN stat /usr/bin/git
 RUN stat /usr/libexec/git-core/git

--- a/integration/dockerfiles/Dockerfile_test_onbuild
+++ b/integration/dockerfiles/Dockerfile_test_onbuild
@@ -1,4 +1,5 @@
-FROM gcr.io/kaniko-test/onbuild-base:latest
+ARG IMAGE_REPO
+FROM ${IMAGE_REPO}onbuild-base:latest
 COPY context/foo foo
 ENV dir /new/workdir/
 ARG file

--- a/integration/images.go
+++ b/integration/images.go
@@ -317,6 +317,7 @@ func (d *DockerFileBuilder) BuildDockerImage(t *testing.T, imageRepo, dockerfile
 	for _, arg := range argsMap[dockerfile] {
 		buildArgs = append(buildArgs, buildArgFlag, arg)
 	}
+	buildArgs = append(buildArgs, buildArgFlag, fmt.Sprintf("IMAGE_REPO=%s", imageRepo))
 
 	// build docker image
 	additionalFlags := append(buildArgs, additionalDockerFlagsMap[dockerfile]...)
@@ -369,6 +370,7 @@ func (d *DockerFileBuilder) BuildImageWithContext(t *testing.T, config *integrat
 	for _, arg := range argsMap[dockerfile] {
 		buildArgs = append(buildArgs, buildArgFlag, arg)
 	}
+	buildArgs = append(buildArgs, buildArgFlag, fmt.Sprintf("IMAGE_REPO=%s", config.imageRepo))
 
 	timer := timing.Start(dockerfile + "_docker")
 	if err := d.BuildDockerImage(t, imageRepo, dockerfilesPath, dockerfile, contextDir); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

As part of the remote onbuild investigation I found that we still rely on a few images from `gcr.io/kaniko-test`, even though we always build them from scratch in the integration tests. With this change we make sure that we always use the images that are created in the integration test session and not external images.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
