### PR TITLE
mz280: fix harbor authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ expect - see [Known Issues](#known-issues).
       - [Caching Layers](#caching-layers)
       - [Caching Base Images](#caching-base-images)
     - [Pushing to Different Registries](#pushing-to-different-registries)
+      - [Credential Provider Priorities](#credential-provider-priorities)
       - [Pushing to Docker Hub](#pushing-to-docker-hub)
       - [Pushing to Google GCR](#pushing-to-google-gcr)
       - [Pushing to GCR using Workload Identity](#pushing-to-gcr-using-workload-identity)
@@ -620,6 +621,11 @@ kaniko uses Docker credential helpers to push images to a registry.
 kaniko comes with support for GCR, Docker `config.json` and Amazon ECR, but
 configuring another credential helper should allow pushing to a different
 registry.
+
+#### Credential Provider Priorities
+
+By default kaniko will configure all built-in credential providers for you. These are `[default, env, google, ecr, acr, gitlab]`.
+You can (de)-activate credential helpers via the [`--credential-helpers`](#flag---credential-helpers) flag. The `default` credential helper will always be active and itself handles two sources: `DOCKER_AUTH_CONFIG` environment variable and `/kaniko/.docker/config.json` file, where priority is always given to `DOCKER_AUTH_CONFIG` and therefore can shadow credentials configured in the config file. If you want to disable `DOCKER_AUTH_CONFIG` you have to unset the environment variable explicitly `unset DOCKER_AUTH_CONFIG` prior to calling kaniko.
 
 #### Pushing to Docker Hub
 

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -178,7 +178,15 @@ var RootCmd = &cobra.Command{
 		}
 		if !opts.NoPush || opts.CacheRepo != "" {
 			if err := executor.CheckPushPermissions(opts); err != nil {
-				exit(fmt.Errorf("error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: %w", err))
+				logrus.Warnf("make sure you entered the correct tag name, that you are authenticated correctly, and try again.")
+				// mz280: remind users that DOCKER_AUTH_CONFIG gets prioritized by docker-cli
+				// https://github.com/docker/cli/pull/6171
+				_, ok := os.LookupEnv("DOCKER_AUTH_CONFIG")
+				if ok {
+					logrus.Warnf("note that your DOCKER_AUTH_CONFIG env variable can shadow credentials from configfile")
+					logrus.Warnf("see https://github.com/osscontainertools/kaniko/issues/280#issuecomment-3498449955")
+				}
+				exit(fmt.Errorf("error checking push permissions: %w", err))
 			}
 		}
 		if err := resolveRelativePaths(); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/280 https://github.com/chainguard-dev/kaniko/issues/184

**Description**

docker cli auth (default provider) actually handles two credential sources internally. `DOCKER_AUTH_CONFIG` environment variable and `/kaniko/.docker/config.json` file. It always gives priority to the environment variable https://github.com/docker/cli/pull/6171. This causes issues where users had read-only credentials for harbor configured instance wide in the environment variable and push credentials stored in the local configfile. Our usage of docker cli would ignore the push credentials and instead fail hard with the readonly credentials.

In a sense this is similar to the issue we had with google credential helper here https://github.com/GoogleContainerTools/kaniko/issues/3328, where we implicitly used invalid credentials to authenticate to gcr, and then failed even though the repository was public. The underlying issue is that if authentication of the highest priority key fails, we just give up, instead we should try out unauthenticated and all keys in order by default, this way credentials can't be shadowed by "higher priority" ones.

As a stop-gap solution to improve the discoverability of these kind of issues we now explicitly log the used credential providers and add an additional warning if `DOCKER_AUTH_CONFIG` can shadow your other configs.