### PR TITLE
969: cache mount option flags

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_969
+++ b/integration/dockerfiles/Dockerfile_test_issue_969
@@ -17,3 +17,13 @@ RUN --mount=type=cache,id=1234,target=/tmp/bli/bla \
 RUN --mount=type=cache,target=/tmp/bli/bla \
     ls -la /tmp/bli/bla/ \
     && test -f /tmp/bli/bla/blubb
+
+# we can control uid:gid:mode for our mount folder
+RUN --mount=type=cache,target=/tmp/bli/bla,uid=1000,gid=1000,mode=0700 \
+    out=`stat -c '%u:%g:%A' /tmp/bli/bla` \
+    && echo $out | tee /stat1.txt \
+    && [ $out = "1000:1000:drwx------" ]
+
+# but these permissions get reset correctly to the defaults
+RUN --mount=type=cache,target=/tmp/bli/bla \
+    stat -c '%u %g %A' /tmp/bli/bla | tee /stat2.txt


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Brings more options to cache mount that were not added in the first implementation round
https://docs.docker.com/reference/dockerfile/#run---mounttypecache


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
