### PR TITLE
chore(ci): run staticcheck

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -33,3 +33,9 @@ jobs:
           check-latest: true
 
       - run: make test
+
+      - name: Run staticcheck 
+        uses: dominikh/staticcheck-action@v1.4.0
+        with:
+          install-go: false
+          version: 'latest'


### PR DESCRIPTION
Related to https://github.com/osscontainertools/kaniko/pull/442 (and depends on it)

**Description**

Just to avoid reintroducing more issues in the future, thought I'd add a CI step. I initially also had a Makefile entry with `go tools` but honestly not sure about vendoring all that just for tooling - I'll open a separate issue for the vendoring topic :sweat_smile: 

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.
