### PR TITLE
mz487: allow squashing pure copydependencies again

### DIFF
--- a/golden/golden_test.go
+++ b/golden/golden_test.go
@@ -30,6 +30,7 @@ import (
 	testissuemz195 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz195"
 	testissuemz333 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz333"
 	testissuemz338 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz338"
+	testissuemz487 "github.com/osscontainertools/kaniko/golden/testdata/test_issue_mz487"
 	testunittests "github.com/osscontainertools/kaniko/golden/testdata/test_unittests"
 	"github.com/osscontainertools/kaniko/golden/types"
 	"github.com/osscontainertools/kaniko/pkg/config"
@@ -62,6 +63,7 @@ var allTests = map[string][]types.GoldenTests{
 	"test_issue_mz195": {testissuemz195.Tests},
 	"test_issue_mz333": {testissuemz333.Tests},
 	"test_issue_mz338": {testissuemz338.Tests},
+	"test_issue_mz487": {testissuemz487.Tests},
 	"test_unittests":   testunittests.Tests,
 }
 var update bool

--- a/golden/testdata/test_issue_mz487/Dockerfile
+++ b/golden/testdata/test_issue_mz487/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine AS base
+RUN install
+
+FROM base AS intermediate
+RUN install more
+
+# mz487: in kaniko v1.26.1-v1.26.4 we had a regression whereby
+# the build stage would not be squashed into the intermediate stage,
+# as it was a pure CopyDependency.
+FROM intermediate AS build
+RUN compile
+
+FROM base AS final
+COPY --from=build output output

--- a/golden/testdata/test_issue_mz487/plans/plan
+++ b/golden/testdata/test_issue_mz487/plans/plan
@@ -1,0 +1,16 @@
+FROM alpine AS base
+UNPACK alpine
+RUN install
+SAVE STAGE /kaniko/stages/0
+CLEAN
+
+FROM base AS build
+UNPACK /kaniko/stages/0
+RUN install more
+RUN compile
+SAVE FILES [output] /kaniko/deps/2
+CLEAN
+
+FROM base AS final
+UNPACK /kaniko/stages/0
+COPY --from=build output output

--- a/golden/testdata/test_issue_mz487/test.go
+++ b/golden/testdata/test_issue_mz487/test.go
@@ -1,0 +1,14 @@
+package testissuemz487
+
+import "github.com/osscontainertools/kaniko/golden/types"
+
+var Tests = types.GoldenTests{
+	Name:       "test_issue_mz487",
+	Dockerfile: "Dockerfile",
+	Tests: []types.GoldenTest{
+		{
+			Args: []string{"--no-push"},
+			Plan: "plan",
+		},
+	},
+}

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -359,7 +359,7 @@ func MakeKanikoStages(opts *config.KanikoOptions, stages []instructions.Stage, m
 	}
 	if opts.SkipUnusedStages && config.EnvBoolDefault("FF_KANIKO_SQUASH_STAGES", true) {
 		for i, s := range kanikoStages {
-			if stagesDependencies[i] > 0 {
+			if stagesDependencies[i] > 0 || copyDependencies[i] > 0 {
 				if s.BaseImageStoredLocally && stagesDependencies[s.BaseImageIndex] == 1 && copyDependencies[s.BaseImageIndex] == 0 {
 					sb := kanikoStages[s.BaseImageIndex]
 					// squash stages[i] into stages[i].BaseName


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/487

**Description**

Our squashing logic has an optimization, we don't even attempt to squash if the stage is not used anyways. However, when we split the meaning of `stagesDependencies` and `copyDependencies` in https://github.com/osscontainertools/kaniko/pull/335, we did not update that optimization. As a result squashing was only applied to the former.


