### PR TITLE
mz468: refs/pull is not a valid branchname

### DIFF
--- a/pkg/buildcontext/git.go
+++ b/pkg/buildcontext/git.go
@@ -76,13 +76,11 @@ func (g *Git) UnpackTarFromBuildContext() (string, error) {
 			// Fetch the sha in case it is an ephemeral commit - ie. merged results pipeline
 			fetchRef = parts[1]
 			checkoutRef = fetchRef
-		} else if strings.HasPrefix(parts[1], "refs/heads/") {
+		} else if strings.HasPrefix(parts[1], "refs/heads/") ||
+			strings.HasPrefix(parts[0], "github.com/") && strings.HasPrefix(parts[1], "refs/pull/") ||
+			strings.HasPrefix(parts[0], "gitlab.com/") && strings.HasPrefix(parts[1], "refs/merge-requests/") {
 			// Full branch ref will be cloned directly
-			options.ReferenceName = plumbing.ReferenceName(parts[1])
-		} else if strings.HasPrefix(parts[0], "github.com/") && strings.HasPrefix(parts[1], "refs/pull/") {
 			// For github, pull-request refs can be cloned like branches directly
-			options.ReferenceName = plumbing.ReferenceName(parts[1])
-		} else if strings.HasPrefix(parts[0], "gitlab.com/") && strings.HasPrefix(parts[1], "refs/merge-requests/") {
 			// For gitlab, merge-request refs can be cloned like branches directly
 			options.ReferenceName = plumbing.ReferenceName(parts[1])
 		} else if strings.HasPrefix(parts[1], "refs/") {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/468

**Description**

Github exposes refs/pull references as branchnames during clone, but that is a github-ism. Other git servers do not need to do that. Only refs/heads are branch names. We therefore change the logic to handle all non-branch references via a three stage approach:

    clone default + fetch ref + checkout commit

We added an exception for github/gitlab to keep behaviour efficient and compatible

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
