### PR TITLE
drop redundant saveStage function

### DIFF
--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -231,25 +231,6 @@ func ParseCommands(cmdArray []string) ([]instructions.Command, error) {
 	return cmds, nil
 }
 
-// SaveStage returns true if the current stage will be needed later in the Dockerfile
-func saveStage(index int, stages []instructions.Stage) bool {
-	currentStageName := stages[index].Name
-
-	for stageIndex, stage := range stages {
-		if stageIndex <= index {
-			continue
-		}
-
-		if strings.ToLower(stage.BaseName) == currentStageName {
-			if stage.BaseName != "" {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 // ResolveCrossStageCommands resolves any calls to previous stages with names to indices
 // Ex. --from=secondStage should be --from=1 for easier processing later on
 // As third party library lowers stage name in FROM instruction, this function resolves stage case insensitively.
@@ -332,16 +313,14 @@ func MakeKanikoStages(opts *config.KanikoOptions, stages []instructions.Stage, m
 		}
 		stage.Commands = append(cmds, stage.Commands...)
 		resolveCrossStageCommands(stage.Commands, stageByName)
-		if opts.SkipUnusedStages {
-			if baseImageStoredLocally {
-				stagesDependencies[baseImageIndex]++
-			}
-			for _, c := range stage.Commands {
-				switch cmd := c.(type) {
-				case *instructions.CopyCommand:
-					if copyFromIndex, err := strconv.Atoi(cmd.From); err == nil {
-						copyDependencies[copyFromIndex]++
-					}
+		if baseImageStoredLocally {
+			stagesDependencies[baseImageIndex]++
+		}
+		for _, c := range stage.Commands {
+			switch cmd := c.(type) {
+			case *instructions.CopyCommand:
+				if copyFromIndex, err := strconv.Atoi(cmd.From); err == nil {
+					copyDependencies[copyFromIndex]++
 				}
 			}
 		}
@@ -351,7 +330,7 @@ func MakeKanikoStages(opts *config.KanikoOptions, stages []instructions.Stage, m
 			Commands:               stage.Commands,
 			BaseImageIndex:         baseImageIndex,
 			BaseImageStoredLocally: baseImageStoredLocally,
-			SaveStage:              saveStage(i, stages),
+			SaveStage:              stagesDependencies[i] > 0,
 			Final:                  i == targetStage,
 			MetaArgs:               metaArgs,
 			Index:                  i,

--- a/pkg/dockerfile/dockerfile_test.go
+++ b/pkg/dockerfile/dockerfile_test.go
@@ -315,55 +315,6 @@ func Test_targetStage(t *testing.T) {
 	}
 }
 
-func Test_SaveStage(t *testing.T) {
-	tests := []struct {
-		name     string
-		index    int
-		expected bool
-	}{
-		{
-			name:     "reference stage in later copy command",
-			index:    0,
-			expected: false,
-		},
-		{
-			name:     "reference stage in later from command",
-			index:    1,
-			expected: true,
-		},
-		{
-			name:     "don't reference stage later",
-			index:    2,
-			expected: false,
-		},
-		{
-			name:     "reference current stage in next stage",
-			index:    4,
-			expected: true,
-		},
-		{
-			name:     "from prebuilt stage, and reference current stage in next stage",
-			index:    5,
-			expected: true,
-		},
-		{
-			name:     "final stage",
-			index:    6,
-			expected: false,
-		},
-	}
-	stages, _, err := Parse([]byte(testutil.Dockerfile))
-	if err != nil {
-		t.Fatalf("couldn't retrieve stages from Dockerfile: %v", err)
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual := saveStage(test.index, stages)
-			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expected, actual)
-		})
-	}
-}
-
 func Test_baseImageIndex(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

a quick win refactoring, we already track dependencies, so we can drop the function that recalculates it inline.
The caveat is that now the dependencies have to be computed whether `SkipUnusedStages` is active or not, but as this is gonna get deprecated soon that conditional will vanish regardless.


