### PR TITLE
mz507: bump docker

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -49,7 +49,13 @@ jobs:
 
       - uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d # v5.0.0
         with:
-          version: 28.5.2
+          version: 29.2.1
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": false
+              }
+            }
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/507

**Description**
bumps docker version to v29, in v29 the local storage for images was changed from docker legacy to containerd. In integration tests we build docker built images locally, and we push kaniko built images to the registry and pull from there, comparison is then performed on the local images.

Containerd image store has the advantage that it can store images in oci format and supports manifests etc. Previously, we would always "normalize" images when we build/pull them into our local legacy storage. This normalization actually has hidden quite a few inconsistencies between our docker/kaniko builds, which now all come to light at once.

Some of our tests actually need to explicitly push images to the registry and compare there, remotely, to check annotations for example, because local storage didn't support that so far. 

With this change we update docker but keep the legacy storage active for now, in a second step we switch to containerd storage and fix the issues that come up.