### PR TITLE
linter: staticcheck

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -58,13 +58,13 @@ func (rc *RegistryCache) RetrieveLayer(ck string) (v1.Image, error) {
 		return nil, fmt.Errorf("getting reference for %s: %w", cache, err)
 	}
 
-	registryName := cacheRef.Repository.Registry.Name()
+	registryName := cacheRef.Registry.Name()
 	if rc.Opts.Insecure || rc.Opts.InsecureRegistries.Contains(registryName) {
 		newReg, err := name.NewRegistry(registryName, name.WeakValidation, name.Insecure)
 		if err != nil {
 			return nil, err
 		}
-		cacheRef.Repository.Registry = newReg
+		cacheRef.Registry = newReg
 	}
 
 	tr, err := util.MakeTransport(rc.Opts.RegistryOptions, registryName)

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -101,7 +101,7 @@ func (a *AddCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 		}
 	}
 	// With the remaining "normal" sources, create and execute a standard copy command
-	heredocs := a.cmd.SourcesAndDest.SourceContents
+	heredocs := a.cmd.SourceContents
 	if len(unresolvedSrcs) == 0 && len(heredocs) == 0 {
 		return nil
 	}

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -140,7 +140,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 	}
 
 	// Heredocs
-	for _, src := range c.cmd.SourcesAndDest.SourceContents {
+	for _, src := range c.cmd.SourceContents {
 		fullPath := filepath.Join(c.fileContext.Root, src.Path)
 		cwd := config.WorkingDir
 		if cwd == "" {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -669,7 +669,7 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
 					if err != nil {
 						continue
 					}
-					resolved, err := util.ResolveEnvironmentReplacementList(cmd.SourcesAndDest.SourcePaths, ba.ReplacementEnvs(cfg.Config.Env), true)
+					resolved, err := util.ResolveEnvironmentReplacementList(cmd.SourcePaths, ba.ReplacementEnvs(cfg.Config.Env), true)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -1642,7 +1642,7 @@ func Test_stageBuild_populateCompositeKeyForCopyCommand(t *testing.T) {
 
 			for _, useCacheCommand := range []bool{false, true} {
 				t.Run(fmt.Sprintf("CacheCommand=%t", useCacheCommand), func(t *testing.T) {
-					var cmd commands.DockerCommand = copyCommand
+					cmd := copyCommand
 					if useCacheCommand {
 						cmd = copyCommand.(*commands.CopyCommand).CacheCommand(nil)
 					}

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -116,13 +116,13 @@ func CheckPushPermissions(opts *config.KanikoOptions) error {
 			continue
 		}
 
-		registryName := destRef.Repository.Registry.Name()
+		registryName := destRef.Registry.Name()
 		if opts.Insecure || opts.InsecureRegistries.Contains(registryName) {
 			newReg, err := name.NewRegistry(registryName, name.WeakValidation, name.Insecure)
 			if err != nil {
 				return fmt.Errorf("getting new insecure registry: %w", err)
 			}
-			destRef.Repository.Registry = newReg
+			destRef.Registry = newReg
 		}
 		rt, err := util.MakeTransport(opts.RegistryOptions, registryName)
 		if err != nil {
@@ -262,13 +262,13 @@ func DoPush(image v1.Image, opts *config.KanikoOptions) error {
 
 	// continue pushing unless an error occurs
 	for _, destRef := range destRefs {
-		registryName := destRef.Repository.Registry.Name()
+		registryName := destRef.Registry.Name()
 		if opts.Insecure || opts.InsecureRegistries.Contains(registryName) {
 			newReg, err := name.NewRegistry(registryName, name.WeakValidation, name.Insecure)
 			if err != nil {
 				return fmt.Errorf("getting new insecure registry: %w", err)
 			}
-			destRef.Repository.Registry = newReg
+			destRef.Registry = newReg
 		}
 
 		pushAuth, err := creds.GetKeychain(&opts.RegistryOptions).Resolve(destRef.Context().Registry)

--- a/pkg/image/remote/remote.go
+++ b/pkg/image/remote/remote.go
@@ -134,10 +134,10 @@ func setNewRepository(ref name.Reference, newRepo name.Repository) name.Referenc
 func setNewRegistry(ref name.Reference, newReg name.Registry) name.Reference {
 	switch r := ref.(type) {
 	case name.Tag:
-		r.Repository.Registry = newReg
+		r.Registry = newReg
 		return r
 	case name.Digest:
-		r.Repository.Registry = newReg
+		r.Registry = newReg
 		return r
 	default:
 		return ref

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -531,10 +531,7 @@ func RelativeFiles(fp string, root string) ([]string, error) {
 func ParentDirectories(path string) []string {
 	dir := filepath.Clean(path)
 	var paths []string
-	for {
-		if dir == filepath.Clean(config.RootDir) || dir == "" || dir == "." {
-			break
-		}
+	for !(dir == filepath.Clean(config.RootDir) || dir == "" || dir == ".") {
 		dir, _ = filepath.Split(dir)
 		dir = filepath.Clean(dir)
 		paths = append([]string{dir}, paths...)
@@ -1198,10 +1195,7 @@ func createParentDirectory(path string, uid int, gid int) error {
 
 		dir := baseDir
 		dirs := []string{baseDir}
-		for {
-			if dir == "/" || dir == "." || dir == "" {
-				break
-			}
+		for !(dir == "/" || dir == "." || dir == "") {
 			dir = filepath.Dir(dir)
 			dirs = append(dirs, dir)
 		}
@@ -1380,7 +1374,7 @@ func GetFSInfoMap(dir string, existing map[string]os.FileInfo) (map[string]os.Fi
 func isSame(fi1, fi2 os.FileInfo) bool {
 	return fi1.Mode() == fi2.Mode() &&
 		// file modification time
-		fi1.ModTime() == fi2.ModTime() &&
+		fi1.ModTime().Equal(fi2.ModTime()) &&
 		// file size
 		fi1.Size() == fi2.Size() &&
 		// file user id


### PR DESCRIPTION
addresses some (not all) issues raised by

```bash
golangci-lint run --no-config --default none --enable staticcheck --fix
```

note that QF1001 (De Morgan's Law) is ignored