### PR TITLE
mz507: stop propagating base image annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_RUN_VIA_TINI`](#flag-ff_kaniko_run_via_tini)
       - [Flag `FF_KANIKO_COPY_CHMOD_ON_IMPLICIT_DIRS`](#flag-ff_kaniko_copy_chmod_on_implicit_dirs)
       - [Flag `FF_KANIKO_CLEAN_KANIKO_DIR`](#flag-ff_kaniko_clean_kaniko_dir)
+      - [Flag `FF_KANIKO_NO_PROPAGATE_ANNOTATIONS`](#flag-ff_kaniko_no_propagate_annotations)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1128,6 +1129,12 @@ Currently no plans to activate.
 
 When using `--cleanup`, kaniko cleans the container filesystem at the end of the build. Set this flag to `true` to also remove kaniko's own working directory artifacts from `/kaniko` (the Dockerfile copy, build context, intermediate stages, inter-stage dependencies, layers cache, and secrets). This is useful when reusing a kaniko container across multiple builds.
 Defaults to `true`.
+
+#### Flag `FF_KANIKO_NO_PROPAGATE_ANNOTATIONS`
+
+When building from a base image that carries OCI manifest annotations (e.g. `org.opencontainers.image.url`, `org.opencontainers.image.version`), kaniko by default propagates those annotations into the output image manifest. This differs from Docker/BuildKit behaviour, which does not carry base image annotations forward into derived images.
+Set this flag to `true` to strip base image manifest annotations from the output, matching Docker behaviour. Defaults to `false`.
+Becomes default in `v1.28.0`.
 
 ### Debug Image
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -92,6 +92,10 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 		return nil, err
 	}
 
+	if config.EnvBool("FF_KANIKO_NO_PROPAGATE_ANNOTATIONS") {
+		sourceImage = mutate.Annotations(sourceImage, nil).(v1.Image)
+	}
+
 	_opts := *opts
 	if !stage.Push {
 		_opts.Labels = []string{}
@@ -101,6 +105,8 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 		return nil, err
 	}
 
+	// mz507: This workaround to prevent cache invalidation via base image annotations
+	// can be removed once FF_KANIKO_NO_PROPAGATE_ANNOTATIONS becomes standard.
 	man, err := sourceImage.Manifest()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**
Kaniko propagates OCI manifest annotations from the base image forwards. This became visible when updating to Docker 29.0.0, which switched to the containerd image store by default. The containerd store preserves OCI manifest annotations when pulling images, so we started noticing the difference with the upgrade, but it pre-existed.

We added FF_KANIKO_NO_PROPAGATE_ANNOTATIONS to strip base image annotations from the output manifest, matching Docker behaviour.
