### PR TITLE
mz560: fix handling of ignoreList

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_ignore_path_subtree
+++ b/integration/dockerfiles/Dockerfile_test_ignore_path_subtree
@@ -1,0 +1,4 @@
+FROM scratch
+# mz560: in kaniko v1.27.0, when built with --ignore-path=/dest,
+# the file copied into /dest/subdir/ would slip through and end up in the layer.
+COPY context/foo /dest/subdir/file.txt

--- a/integration/dockerfiles/Dockerfile_test_prefix_match_only
+++ b/integration/dockerfiles/Dockerfile_test_prefix_match_only
@@ -1,0 +1,7 @@
+FROM alpine
+# mz560: Simulates apt-key writing temporary key material under /tmp/apt-key-gpghome.
+# The directory itself should appear in the image layer, but files inside it
+# should be excluded because /tmp/apt-key-gpghome is on the ignore list with
+# PrefixMatchOnly=true.
+RUN mkdir /tmp/apt-key-gpghome && \
+    echo "key material" > /tmp/apt-key-gpghome/pubring.gpg

--- a/integration/images.go
+++ b/integration/images.go
@@ -165,6 +165,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_maintainer":             {"--single-snapshot"},
 	"Dockerfile_test_target":                 {"--target=second"},
 	"Dockerfile_test_snapshotter_ignorelist": {"--use-new-run=true", "-v=trace"},
+	"Dockerfile_test_ignore_path_subtree":    {"--ignore-path=/dest"},
 	"Dockerfile_test_issue_mz334":            {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache":                  {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache_oci":              {"--cache-copy-layers=true"},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -705,6 +705,67 @@ func pushMaliciousPathTraversalImage(imageRef string) error {
 	return nil
 }
 
+// mz560: TestPrefixMatchOnlyIgnoreList verifies that an ignore list entry with
+// PrefixMatchOnly=true excludes files inside the directory from the snapshot
+// but still captures the directory node itself.
+// The canonical example is /tmp/apt-key-gpghome: apt-key writes temporary GPG
+// key files there during a build; they must not end up in the image layer.
+func TestPrefixMatchOnlyIgnoreList(t *testing.T) {
+	dockerfile := "Dockerfile_test_prefix_match_only"
+	buildImage(t, dockerfile, imageBuilder)
+	kanikoImage := GetKanikoImage(config.imageRepo, dockerfile)
+
+	kanikoFiles, err := getLastLayerFiles(kanikoImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		gpghomeDir  = "tmp/apt-key-gpghome"
+		gpghomeFile = "tmp/apt-key-gpghome/pubring.gpg"
+	)
+
+	var hasDir, hasFile bool
+	for _, f := range kanikoFiles {
+		switch strings.TrimSuffix(f, "/") {
+		case gpghomeDir:
+			hasDir = true
+		case gpghomeFile:
+			hasFile = true
+		}
+	}
+
+	if !hasDir {
+		t.Errorf("expected %s directory to be present in layer (PrefixMatchOnly=true should not exclude the directory itself), got %v", gpghomeDir, kanikoFiles)
+	}
+	if hasFile {
+		t.Errorf("expected %s to be excluded from layer (child of PrefixMatchOnly=true ignore entry), got %v", gpghomeFile, kanikoFiles)
+	}
+}
+
+// mz560: TestIgnorePathSubtree verifies that --ignore-path excludes not just the named
+// path but also any files nested beneath it. The observable difference: with an
+// exact-match-only check (IsInProvidedIgnoreList), a COPY into /dest/subdir/
+// would pass the ResolvePaths input guard and appear in the layer even when
+// --ignore-path=/dest is set. CheckCleanedPathAgainstProvidedIgnoreList (prefix
+// match) catches the nested path and keeps it out of the layer.
+func TestIgnorePathSubtree(t *testing.T) {
+	dockerfile := "Dockerfile_test_ignore_path_subtree"
+	buildImage(t, dockerfile, imageBuilder)
+	kanikoImage := GetKanikoImage(config.imageRepo, dockerfile)
+
+	kanikoFiles, err := getLastLayerFiles(kanikoImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, f := range kanikoFiles {
+		if strings.HasPrefix(strings.TrimSuffix(f, "/"), "dest/") {
+			t.Errorf("file %s should be excluded from layer because it is under --ignore-path=/dest, got layer contents: %v", f, kanikoFiles)
+		}
+	}
+}
+
 func TestReplaceFolderWithFileOrLink(t *testing.T) {
 	t.Parallel()
 	dockerfiles := []string{"TestReplaceFolderWithFile", "TestReplaceFolderWithLink"}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -85,7 +85,7 @@ func makeSnapshotter(opts *config.KanikoOptions) (*snapshot.Snapshotter, error) 
 		return nil, err
 	}
 	l := snapshot.NewLayeredMap(hasher)
-	return snapshot.NewSnapshotter(l, config.RootDir), nil
+	return snapshot.NewSnapshotter(l, config.RootDir, util.IgnoreList()), nil
 }
 
 // newStageBuilder returns a new type stageBuilder which contains all the information required to build the stage

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -63,9 +63,9 @@ var (
 )
 
 type snapShotter interface {
-	Init() error
-	TakeSnapshotFS() (string, error)
-	TakeSnapshot([]string, bool) (string, error)
+	Init([]util.IgnoreListEntry) error
+	TakeSnapshotFS([]util.IgnoreListEntry) (string, error)
+	TakeSnapshot([]string, []util.IgnoreListEntry, bool) (string, error)
 }
 
 // stageBuilder contains all fields necessary to build one stage of a Dockerfile
@@ -85,7 +85,7 @@ func makeSnapshotter(opts *config.KanikoOptions) (*snapshot.Snapshotter, error) 
 		return nil, err
 	}
 	l := snapshot.NewLayeredMap(hasher)
-	return snapshot.NewSnapshotter(l, config.RootDir, util.IgnoreList()), nil
+	return snapshot.NewSnapshotter(l, config.RootDir), nil
 }
 
 // newStageBuilder returns a new type stageBuilder which contains all the information required to build the stage
@@ -415,7 +415,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 	initSnapshotTaken := false
 	if opts.SingleSnapshot {
 		t := timing.Start("Initial FS snapshot")
-		if err := snapshotter.Init(); err != nil {
+		if err := snapshotter.Init(util.IgnoreList()); err != nil {
 			return err
 		}
 		timing.DefaultRun.Stop(t)
@@ -469,7 +469,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			// Take initial snapshot if command does not expect to return
 			// a list of files.
 			t := timing.Start("Initial FS snapshot")
-			if err := snapshotter.Init(); err != nil {
+			if err := snapshotter.Init(util.IgnoreList()); err != nil {
 				return err
 			}
 			timing.DefaultRun.Stop(t)
@@ -558,11 +558,11 @@ func takeSnapshot(files []string, shdDelete bool, opts *config.KanikoOptions, sn
 
 	t := timing.Start("Snapshotting FS")
 	if files == nil || opts.SingleSnapshot {
-		snapshot, err = snapshotter.TakeSnapshotFS()
+		snapshot, err = snapshotter.TakeSnapshotFS(util.IgnoreList())
 	} else {
 		// Volumes are very weird. They get snapshotted in the next command.
 		files = append(files, util.Volumes()...)
-		snapshot, err = snapshotter.TakeSnapshot(files, shdDelete)
+		snapshot, err = snapshotter.TakeSnapshot(files, util.IgnoreList(), shdDelete)
 	}
 	timing.DefaultRun.Stop(t)
 	return snapshot, err
@@ -933,7 +933,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	if opts.PreserveContext {
 		if len(kanikoStages) > 1 || opts.PreCleanup || opts.Cleanup {
 			logrus.Info("Creating snapshot of build context")
-			tarball, err = snapshotter.TakeSnapshotFS()
+			tarball, err = snapshotter.TakeSnapshotFS(util.IgnoreList())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/executor/fakes.go
+++ b/pkg/executor/fakes.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/osscontainertools/kaniko/pkg/commands"
 	"github.com/osscontainertools/kaniko/pkg/dockerfile"
+	"github.com/osscontainertools/kaniko/pkg/util"
 )
 
 type fakeSnapShotter struct {
@@ -34,16 +35,16 @@ type fakeSnapShotter struct {
 	initialized bool
 }
 
-func (f *fakeSnapShotter) Init() error {
+func (f *fakeSnapShotter) Init(_ []util.IgnoreListEntry) error {
 	f.initialized = true
 	return nil
 }
 
-func (f *fakeSnapShotter) TakeSnapshotFS() (string, error) {
+func (f *fakeSnapShotter) TakeSnapshotFS(_ []util.IgnoreListEntry) (string, error) {
 	return f.tarPath, nil
 }
 
-func (f *fakeSnapShotter) TakeSnapshot(_ []string, _ bool) (string, error) {
+func (f *fakeSnapShotter) TakeSnapshot(_ []string, _ []util.IgnoreListEntry, _ bool) (string, error) {
 	return f.tarPath, nil
 }
 

--- a/pkg/filesystem/resolve.go
+++ b/pkg/filesystem/resolve.go
@@ -42,7 +42,7 @@ func ResolvePaths(paths []string, wl []util.IgnoreListEntry) (pathsToAdd []strin
 
 	for _, f := range paths {
 		// If the given path is part of the ignorelist ignore it
-		if util.IsInProvidedIgnoreList(f, wl) {
+		if util.CheckCleanedPathAgainstProvidedIgnoreList(filepath.Clean(f), wl) {
 			logrus.Debugf("Path %s is in list to ignore, ignoring it", f)
 			continue
 		}

--- a/pkg/filesystem/resolve_test.go
+++ b/pkg/filesystem/resolve_test.go
@@ -117,7 +117,7 @@ func Test_ResolvePaths(t *testing.T) {
 					link := filepath.Join(dir, "link", f)
 					inputFiles = append(inputFiles, link)
 
-					if util.IsInProvidedIgnoreList(link, wl) {
+					if util.CheckCleanedPathAgainstProvidedIgnoreList(filepath.Clean(link), wl) {
 						t.Logf("skipping %s", link)
 						continue
 					}
@@ -126,7 +126,7 @@ func Test_ResolvePaths(t *testing.T) {
 
 					target := filepath.Join(dir, "target", f)
 
-					if util.IsInProvidedIgnoreList(target, wl) {
+					if util.CheckCleanedPathAgainstProvidedIgnoreList(filepath.Clean(target), wl) {
 						t.Logf("skipping %s", target)
 						continue
 					}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -194,20 +194,10 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	}
 	timer := timing.Start("Resolving Paths")
 
-	filesToAdd := []string{}
-	resolvedFiles, err := filesystem.ResolvePaths(changedPaths, s.ignorelist)
+	filesToAdd, err := filesystem.ResolvePaths(changedPaths, s.ignorelist)
 	if err != nil {
 		return nil, nil, err
 	}
-	for _, path := range resolvedFiles {
-		if util.CheckCleanedPathAgainstProvidedIgnoreList(filepath.Clean(path), s.ignorelist) {
-			logrus.Panic("Unreachable Code: ignored files should already be filtered out above")
-			logrus.Debugf("Not adding %s to layer, as it's ignored", path)
-			continue
-		}
-		filesToAdd = append(filesToAdd, path)
-	}
-
 	logrus.Debugf("Adding to layer: %v", filesToAdd)
 	logrus.Debugf("Deleting in layer: %v", deletedPaths)
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -38,20 +38,19 @@ var snapshotPathPrefix = ""
 
 // Snapshotter holds the root directory from which to take snapshots, and a list of snapshots taken
 type Snapshotter struct {
-	l          *LayeredMap
-	directory  string
-	ignorelist []util.IgnoreListEntry
+	l         *LayeredMap
+	directory string
 }
 
 // NewSnapshotter creates a new snapshotter rooted at d
-func NewSnapshotter(l *LayeredMap, d string, wl []util.IgnoreListEntry) *Snapshotter {
-	return &Snapshotter{l: l, directory: d, ignorelist: wl}
+func NewSnapshotter(l *LayeredMap, d string) *Snapshotter {
+	return &Snapshotter{l: l, directory: d}
 }
 
 // Init initializes a new snapshotter
-func (s *Snapshotter) Init() error {
+func (s *Snapshotter) Init(ignorelist []util.IgnoreListEntry) error {
 	logrus.Info("Initializing snapshotter ...")
-	_, _, err := s.scanFullFilesystem()
+	_, _, err := s.scanFullFilesystem(ignorelist)
 	return err
 }
 
@@ -62,7 +61,7 @@ func (s *Snapshotter) Key() (string, error) {
 
 // TakeSnapshot takes a snapshot of the specified files, avoiding directories in the ignorelist, and creates
 // a tarball of the changed files. Return contents of the tarball, and whether or not any files were changed
-func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string, error) {
+func (s *Snapshotter) TakeSnapshot(files []string, ignorelist []util.IgnoreListEntry, shdCheckDelete bool) (string, error) {
 	err := os.MkdirAll(config.KanikoLayersDir, 0o755)
 	if err != nil {
 		return "", err
@@ -75,7 +74,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 
 	s.l.Snapshot()
 
-	filesToAdd, err := filesystem.ResolvePaths(files, s.ignorelist)
+	filesToAdd, err := filesystem.ResolvePaths(files, ignorelist)
 	if err != nil {
 		return "", err
 	}
@@ -95,7 +94,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 	// Get whiteout paths
 	var filesToWhiteout []string
 	if shdCheckDelete {
-		_, deletedFiles, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), s.ignorelist, func(s string) (bool, error) {
+		_, deletedFiles, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), ignorelist, func(s string) (bool, error) {
 			return true, nil
 		})
 		if err != nil {
@@ -124,7 +123,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 
 // TakeSnapshotFS takes a snapshot of the filesystem, avoiding directories in the ignorelist, and creates
 // a tarball of the changed files.
-func (s *Snapshotter) TakeSnapshotFS() (string, error) {
+func (s *Snapshotter) TakeSnapshotFS(ignorelist []util.IgnoreListEntry) (string, error) {
 	err := os.MkdirAll(config.KanikoLayersDir, 0o755)
 	if err != nil {
 		return "", err
@@ -138,7 +137,7 @@ func (s *Snapshotter) TakeSnapshotFS() (string, error) {
 	t := util.NewTar(f)
 	defer t.Close()
 
-	filesToAdd, filesToWhiteOut, err := s.scanFullFilesystem()
+	filesToAdd, filesToWhiteOut, err := s.scanFullFilesystem(ignorelist)
 	if err != nil {
 		return "", err
 	}
@@ -156,7 +155,7 @@ func (s *Snapshotter) getSnashotPathPrefix() string {
 	return snapshotPathPrefix
 }
 
-func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
+func (s *Snapshotter) scanFullFilesystem(ignorelist []util.IgnoreListEntry) ([]string, []string, error) {
 	logrus.Info("Taking snapshot of full filesystem...")
 
 	// Some of the operations that follow (e.g. hashing) depend on the file system being synced,
@@ -188,13 +187,13 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 
 	logrus.Debugf("Current image filesystem: %v", s.l.currentImage)
 
-	changedPaths, deletedPaths, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), s.ignorelist, s.l.CheckFileChange)
+	changedPaths, deletedPaths, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), ignorelist, s.l.CheckFileChange)
 	if err != nil {
 		return nil, nil, err
 	}
 	timer := timing.Start("Resolving Paths")
 
-	filesToAdd, err := filesystem.ResolvePaths(changedPaths, s.ignorelist)
+	filesToAdd, err := filesystem.ResolvePaths(changedPaths, ignorelist)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -44,8 +44,8 @@ type Snapshotter struct {
 }
 
 // NewSnapshotter creates a new snapshotter rooted at d
-func NewSnapshotter(l *LayeredMap, d string) *Snapshotter {
-	return &Snapshotter{l: l, directory: d, ignorelist: util.IgnoreList()}
+func NewSnapshotter(l *LayeredMap, d string, wl []util.IgnoreListEntry) *Snapshotter {
+	return &Snapshotter{l: l, directory: d, ignorelist: wl}
 }
 
 // Init initializes a new snapshotter
@@ -95,7 +95,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 	// Get whiteout paths
 	var filesToWhiteout []string
 	if shdCheckDelete {
-		_, deletedFiles, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), func(s string) (bool, error) {
+		_, deletedFiles, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), s.ignorelist, func(s string) (bool, error) {
 			return true, nil
 		})
 		if err != nil {
@@ -188,7 +188,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 
 	logrus.Debugf("Current image filesystem: %v", s.l.currentImage)
 
-	changedPaths, deletedPaths, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), s.l.CheckFileChange)
+	changedPaths, deletedPaths, err := util.WalkFS(s.directory, s.l.GetCurrentPaths(), s.ignorelist, s.l.CheckFileChange)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -200,7 +200,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 		return nil, nil, err
 	}
 	for _, path := range resolvedFiles {
-		if util.CheckIgnoreList(path) {
+		if util.CheckCleanedPathAgainstProvidedIgnoreList(filepath.Clean(path), s.ignorelist) {
 			logrus.Debugf("Not adding %s to layer, as it's ignored", path)
 			continue
 		}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -201,6 +201,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 	}
 	for _, path := range resolvedFiles {
 		if util.CheckCleanedPathAgainstProvidedIgnoreList(filepath.Clean(path), s.ignorelist) {
+			logrus.Panic("Unreachable Code: ignored files should already be filtered out above")
 			logrus.Debugf("Not adding %s to layer, as it's ignored", path)
 			continue
 		}

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -48,7 +48,7 @@ func TestSnapshotFSFileChange(t *testing.T) {
 		t.Fatalf("Error setting up fs: %s", err)
 	}
 	// Take another snapshot
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, err := snapshotter.TakeSnapshotFS(util.IgnoreList())
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -112,7 +112,7 @@ func TestSnapshotFSIsReproducible(t *testing.T) {
 		t.Fatalf("Error setting up fs: %s", err)
 	}
 	// Take another snapshot
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, err := snapshotter.TakeSnapshotFS(util.IgnoreList())
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -141,7 +141,7 @@ func TestSnapshotFSChangePermissions(t *testing.T) {
 		t.Fatalf("Error changing permissions on %s: %v", batPath, err)
 	}
 	// Take another snapshot
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, err := snapshotter.TakeSnapshotFS(util.IgnoreList())
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -206,7 +206,7 @@ func TestSnapshotFSReplaceDirWithLink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, err := snapshotter.TakeSnapshotFS(util.IgnoreList())
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -252,7 +252,7 @@ func TestSnapshotFiles(t *testing.T) {
 	filesToSnapshot := []string{
 		filepath.Join(testDir, "foo"),
 	}
-	tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, false)
+	tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, util.IgnoreList(), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +287,7 @@ func TestEmptySnapshotFS(t *testing.T) {
 	defer cleanup()
 
 	// Take snapshot with no changes
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, err := snapshotter.TakeSnapshotFS(util.IgnoreList())
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -389,7 +389,7 @@ func TestSnapshotPreservesFileOrder(t *testing.T) {
 		}
 
 		// Take a snapshot
-		tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, false)
+		tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, util.IgnoreList(), false)
 		if err != nil {
 			t.Fatalf("Error taking snapshot of fs: %s", err)
 		}
@@ -420,7 +420,7 @@ func TestSnapshotIncludesParentDirBeforeWhiteoutFile(t *testing.T) {
 
 	// Take a snapshot
 	filesToSnapshot := []string{filepath.Join(testDir, "kaniko/file", "bar/bat")}
-	_, err = snapshotter.TakeSnapshot(filesToSnapshot, false)
+	_, err = snapshotter.TakeSnapshot(filesToSnapshot, util.IgnoreList(), false)
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -444,7 +444,7 @@ func TestSnapshotIncludesParentDirBeforeWhiteoutFile(t *testing.T) {
 	}
 
 	// Take a snapshot again
-	tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, true)
+	tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, util.IgnoreList(), true)
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -510,7 +510,7 @@ func TestSnapshotPreservesWhiteoutOrder(t *testing.T) {
 		}
 
 		// Take a snapshot
-		_, err = snapshotter.TakeSnapshot(filesToSnapshot, false)
+		_, err = snapshotter.TakeSnapshot(filesToSnapshot, util.IgnoreList(), false)
 		if err != nil {
 			t.Fatalf("Error taking snapshot of fs: %s", err)
 		}
@@ -524,7 +524,7 @@ func TestSnapshotPreservesWhiteoutOrder(t *testing.T) {
 		}
 
 		// Take a snapshot again
-		tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, true)
+		tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, util.IgnoreList(), true)
 		if err != nil {
 			t.Fatalf("Error taking snapshot of fs: %s", err)
 		}
@@ -554,7 +554,7 @@ func TestSnapshotOmitsUnameGname(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, err := snapshotter.TakeSnapshotFS(util.IgnoreList())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,8 +619,8 @@ func setUpTest(t *testing.T) (string, *Snapshotter, func(), error) {
 
 	// Take the initial snapshot
 	l := NewLayeredMap(util.Hasher())
-	snapshotter := NewSnapshotter(l, testDir, util.IgnoreList())
-	if err := snapshotter.Init(); err != nil {
+	snapshotter := NewSnapshotter(l, testDir)
+	if err := snapshotter.Init(util.IgnoreList()); err != nil {
 		return "", nil, nil, fmt.Errorf("initializing snapshotter: %w", err)
 	}
 

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -619,7 +619,7 @@ func setUpTest(t *testing.T) (string, *Snapshotter, func(), error) {
 
 	// Take the initial snapshot
 	l := NewLayeredMap(util.Hasher())
-	snapshotter := NewSnapshotter(l, testDir)
+	snapshotter := NewSnapshotter(l, testDir, util.IgnoreList())
 	if err := snapshotter.Init(); err != nil {
 		return "", nil, nil, fmt.Errorf("initializing snapshotter: %w", err)
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -430,17 +430,6 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 	return nil
 }
 
-func IsInProvidedIgnoreList(path string, wl []IgnoreListEntry) bool {
-	path = filepath.Clean(path)
-	for _, entry := range wl {
-		if !entry.PrefixMatchOnly && path == entry.Path {
-			return true
-		}
-	}
-
-	return false
-}
-
 func CheckCleanedPathAgainstProvidedIgnoreList(path string, wl []IgnoreListEntry) bool {
 	for _, wl := range ignorelist {
 		if hasCleanedFilepathPrefix(path, wl.Path, wl.PrefixMatchOnly) {
@@ -1342,7 +1331,7 @@ func gowalkDir(dir string, existingPaths map[string]struct{}, wl []IgnoreListEnt
 			return err
 		}
 
-		if IsInProvidedIgnoreList(path, wl) {
+		if CheckCleanedPathAgainstProvidedIgnoreList(filepath.Clean(path), wl) {
 			if IsDestDir(path) && info.IsDir() {
 				logrus.Tracef("Skipping paths under '%s', as it is an ignored directory", path)
 				return filepath.SkipDir

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -431,8 +431,8 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 }
 
 func CheckCleanedPathAgainstProvidedIgnoreList(path string, wl []IgnoreListEntry) bool {
-	for _, wl := range ignorelist {
-		if hasCleanedFilepathPrefix(path, wl.Path, wl.PrefixMatchOnly) {
+	for _, w := range wl {
+		if hasCleanedFilepathPrefix(path, w.Path, w.PrefixMatchOnly) {
 			return true
 		}
 	}

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -441,10 +441,6 @@ func IsInProvidedIgnoreList(path string, wl []IgnoreListEntry) bool {
 	return false
 }
 
-func IsInIgnoreList(path string) bool {
-	return IsInProvidedIgnoreList(path, ignorelist)
-}
-
 func CheckCleanedPathAgainstProvidedIgnoreList(path string, wl []IgnoreListEntry) bool {
 	for _, wl := range ignorelist {
 		if hasCleanedFilepathPrefix(path, wl.Path, wl.PrefixMatchOnly) {
@@ -1303,6 +1299,7 @@ type walkFSResult struct {
 func WalkFS(
 	dir string,
 	existingPaths map[string]struct{},
+	wl []IgnoreListEntry,
 	changeFunc func(string) (bool, error),
 ) ([]string, map[string]struct{}, error) {
 	timeOutStr := os.Getenv(snapshotTimeout)
@@ -1319,7 +1316,7 @@ func WalkFS(
 	ch := make(chan walkFSResult, 1)
 
 	go func() {
-		filesAdded, existingPaths, err := gowalkDir(dir, existingPaths, changeFunc)
+		filesAdded, existingPaths, err := gowalkDir(dir, existingPaths, wl, changeFunc)
 		ch <- walkFSResult{filesAdded, existingPaths, err}
 	}()
 
@@ -1335,7 +1332,7 @@ func WalkFS(
 	}
 }
 
-func gowalkDir(dir string, existingPaths map[string]struct{}, changeFunc func(string) (bool, error)) ([]string, map[string]struct{}, error) {
+func gowalkDir(dir string, existingPaths map[string]struct{}, wl []IgnoreListEntry, changeFunc func(string) (bool, error)) ([]string, map[string]struct{}, error) {
 	foundPaths := make([]string, 0)
 	deletedFiles := existingPaths // Make a reference.
 
@@ -1345,7 +1342,7 @@ func gowalkDir(dir string, existingPaths map[string]struct{}, changeFunc func(st
 			return err
 		}
 
-		if IsInIgnoreList(path) {
+		if IsInProvidedIgnoreList(path, wl) {
 			if IsDestDir(path) && info.IsDir() {
 				logrus.Tracef("Skipping paths under '%s', as it is an ignored directory", path)
 				return filepath.SkipDir


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


In preparation for https://github.com/osscontainertools/kaniko/issues/560

**Description**
The handling of `ignoreLists` was a bit confused. There is a global variable `util.ignoreList` that gets initialized on bootup and is basically used for most tasks, but even functions that accept a ignorelist as a parameter would just at some depth fall back to read the global variable instead, clearly a bug. Fixing that bug however uncovered another incosistency. There are two functions to check whether a given path is in the ignoreList or not.
* `IsInProvidedIgnoreList` checks whether that path is in the ignoreList literally, it is used for managing the list, as in check whether for my specific path an entry already exists or not.
* `CheckCleanedPathAgainstProvidedIgnoreList` checks whether a given path should be ignored based on the ignoreList, this is different to the above, as `/dev/sda1` should be ignored if there is an entry for `/dev`.

The code did use the former function when the latter should be used, there is no single code section where we have to manage the ignoreList so the former function can be dropped altogether.
