### PR TITLE
mz507: docker upgrade part 3

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -48,12 +48,8 @@ jobs:
           persist-credentials: false
 
       - uses: docker/setup-docker-action@1a6edb0ba9ac496f6850236981f15d8f9a82254d # v5.0.0
-        id: setup-docker
         with:
           version: 29.2.1
 
-      - run: sudo apt install -y libgpgme-dev libassuan-dev libbtrfs-dev pkg-config # skopeo dependencies
-      - run: make install-diffoci install-skopeo k3s-setup
+      - run: make install-diffoci k3s-setup
       - run: make ${{ matrix.make-target }}
-        env:
-          DOCKER_HOST: ${{ steps.setup-docker.outputs.sock }}

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,6 @@ install-diffoci:
 		go mod vendor && \
 		go install
 
-.PHONY: install-skopeo
-install-skopeo:
-	@ GOFLAGS="" go install github.com/containers/skopeo/cmd/skopeo@latest
 
 .PHONY: k3s-setup
 k3s-setup:

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ out/warmer: $(GO_FILES)
 install-diffoci:
 	@ git clone https://github.com/mzihlmann/diffoci.git && \
 		cd diffoci/cmd/diffoci && \
+		git checkout 95fcda482de24c04a8e36a57657c4321be0d53f0 && \
 		go mod vendor && \
 		go install
 

--- a/integration/images.go
+++ b/integration/images.go
@@ -95,6 +95,7 @@ var KanikoEnv = []string{
 	"FF_KANIKO_OCI_WARMER=1",
 	"FF_KANIKO_RUN_VIA_TINI=1",
 	"FF_KANIKO_COPY_CHMOD_ON_IMPLICIT_DIRS=1",
+	"FF_KANIKO_NO_PROPAGATE_ANNOTATIONS=1",
 }
 
 var WarmerEnv = []string{

--- a/integration/images.go
+++ b/integration/images.go
@@ -103,9 +103,51 @@ var WarmerEnv = []string{
 
 // Arguments to build Dockerfiles with when building with docker
 var additionalDockerFlagsMap = map[string][]string{
-	"Dockerfile_test_target":      {"--target=second"},
+	"Dockerfile_test_target":      {"--target=second", "--provenance=false"},
 	"Dockerfile_test_issue_cg188": {"--secret=id=netrc,env=SECRET"},
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=context/foo"},
+	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
+	"Dockerfile_test_mv_add":                       {"--provenance=false"},
+	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},
+	"Dockerfile_test_workdir_with_user":            {"--provenance=false"},
+	"Dockerfile_test_whitelist":                    {"--provenance=false"},
+	"Dockerfile_test_volume_4":                     {"--provenance=false"},
+	"Dockerfile_test_volume_3":                     {"--provenance=false"},
+	"Dockerfile_test_maintainer":                   {"--provenance=false"},
+	"Dockerfile_test_meta_arg":                     {"--provenance=false"},
+	"Dockerfile_test_replaced_symlinks":            {"--provenance=false"},
+	"Dockerfile_test_scratch":                      {"--provenance=false"},
+	"Dockerfile_test_registry":                     {"--provenance=false"},
+	"Dockerfile_test_pre_defined_build_args":       {"--provenance=false"},
+	"Dockerfile_test_replaced_hardlinks":           {"--provenance=false"},
+	"Dockerfile_test_issue_647":                    {"--provenance=false"},
+	"Dockerfile_test_copy_root_multistage":         {"--provenance=false"},
+	"Dockerfile_test_issue_1965":                   {"--provenance=false"},
+	"Dockerfile_test_issue_1007":                   {"--provenance=false"},
+	"Dockerfile_test_ignore":                       {"--provenance=false"},
+	"Dockerfile_test_issue_1837":                   {"--provenance=false"},
+	"Dockerfile_test_issue_2049":                   {"--provenance=false"},
+	"Dockerfile_test_dockerignore":                 {"--provenance=false"},
+	"Dockerfile_test_issue_1039":                   {"--provenance=false"},
+	"Dockerfile_test_dangling_symlink":             {"--provenance=false"},
+	"Dockerfile_test_copyadd_chmod":                {"--provenance=false"},
+	"Dockerfile_test_copy_symlink":                 {"--provenance=false"},
+	"Dockerfile_test_copy_same_file_many_times":    {"--provenance=false"},
+	"Dockerfile_test_copy_reproducible":            {"--provenance=false"},
+	"Dockerfile_test_copy_chown_intermediate_dirs": {"--provenance=false"},
+	"Dockerfile_test_copy":                         {"--provenance=false"},
+	"Dockerfile_test_copy_bucket":                  {"--provenance=false"},
+	"Dockerfile_test_complex_substitution":         {"--provenance=false"},
+	"Dockerfile_test_cache_copy_oci":               {"--provenance=false"},
+	"Dockerfile_test_add_url_with_arg":             {"--provenance=false"},
+	"Dockerfile_test_add_dest_symlink_dir":         {"--provenance=false"},
+	"Dockerfile_test_add_chown_intermediate_dirs":  {"--provenance=false"},
+	"Dockerfile_test_arg_two_level":                {"--provenance=false"},
+	"Dockerfile_test_arg_multi_empty_val":          {"--provenance=false"},
+	"issue-1020":                                   {"--provenance=false"},
+	"issue-774":                                    {"--provenance=false"},
+	"issue-1315":                                   {"--provenance=false"},
+	"dockerfiles/Dockerfile_relative_copy":         {"--provenance=false"},
 }
 
 // Override which kaniko executor image to use for a specific test
@@ -632,15 +674,15 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 	dockerImage := GetDockerImage(imageRepo, "test_relative_"+dockerfile)
 	kanikoImage := GetKanikoImage(imageRepo, "test_relative_"+dockerfile)
 
-	dockerCmd := exec.Command("docker",
-		[]string{
-			"build",
-			"--push",
-			"-t", dockerImage,
-			"-f", dockerfile,
-			"./context",
-		}...,
-	)
+	dockerArgs := []string{
+		"build",
+		"--push",
+		"-t", dockerImage,
+		"-f", dockerfile,
+		"./context",
+	}
+	dockerArgs = append(dockerArgs, additionalDockerFlagsMap[dockerfile]...)
+	dockerCmd := exec.Command("docker", dockerArgs...)
 
 	timer := timing.Start(dockerfile + "_docker")
 	out, err := RunCommandWithoutTest(dockerCmd)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1328,7 +1328,7 @@ func initIntegrationTestConfig() *integrationTestConfig {
 }
 
 func meetsRequirements() bool {
-	requiredTools := []string{"diffoci", "skopeo"}
+	requiredTools := []string{"diffoci"}
 	hasRequirements := true
 	for _, tool := range requiredTools {
 		_, err := exec.LookPath(tool)
@@ -1343,16 +1343,14 @@ func meetsRequirements() bool {
 // containerDiff compares the container images image1 and image2.
 func containerDiff(t *testing.T, image1, image2 string, flags ...string) {
 	// workaround for container-diff OCI issue https://github.com/GoogleContainerTools/container-diff/issues/389
-	out, err := skopeoPull(image1)
-	if err != nil {
-		t.Fatalf("failed to pull image %s: %v\n%s", image1, err, string(out))
-	}
+	dockerPullCmd := exec.Command("docker", "pull", image1)
+	out := RunCommand(dockerPullCmd, t)
+	t.Logf("docker pull cmd output for image1 = %s", string(out))
 	image1 = daemonPrefix + image1
 
-	out, err = skopeoPull(image2)
-	if err != nil {
-		t.Fatalf("failed to pull image %s: %v\n%s", image2, err, string(out))
-	}
+	dockerPullCmd = exec.Command("docker", "pull", image2)
+	out = RunCommand(dockerPullCmd, t)
+	t.Logf("docker pull cmd output for image2 = %s", string(out))
 	image2 = daemonPrefix + image2
 
 	flags = append([]string{"diff"}, flags...)
@@ -1362,20 +1360,4 @@ func containerDiff(t *testing.T, image1, image2 string, flags ...string) {
 	containerdiffCmd := exec.Command("diffoci", flags...)
 	diff := RunCommand(containerdiffCmd, t)
 	t.Logf("diff = %s", string(diff))
-}
-
-func skopeoPull(image string) ([]byte, error) {
-	taggedRef := image + ":latest"
-	daemonHost := os.Getenv("DOCKER_HOST")
-	if daemonHost == "" {
-		daemonHost = "unix:///var/run/docker.sock"
-	}
-	src_opts := "--src-tls-verify=false"
-	src := "docker://"
-	cmd := exec.Command("skopeo", "copy",
-		src_opts,
-		src+taggedRef,
-		"--dest-daemon-host", daemonHost,
-		"docker-daemon:"+taggedRef)
-	return RunCommandWithoutTest(cmd)
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -34,7 +34,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -987,50 +986,6 @@ func TestBuildWithAnnotations(t *testing.T) {
 		t.Errorf("Failed to build image %s with kaniko command %q: %v %s", dockerImage, kanikoCmd.Args, err, string(out))
 	}
 	containerDiff(t, dockerImage, kanikoImage, "--ignore-history")
-
-	dockerAnnotations, err := getImageManifestAnnotations(t, dockerImage)
-	if err != nil {
-		t.Fatalf("Failed to get annotations for docker image %s: %v", dockerImage, err)
-	}
-	if len(dockerAnnotations) == 0 {
-		t.Fatalf("No annotations found for docker image %s", dockerImage)
-	}
-
-	kanikoAnnotations, err := getImageManifestAnnotations(t, kanikoImage)
-	if err != nil {
-		t.Fatalf("Failed to get annotations for kaniko image %s: %v", kanikoImage, err)
-	}
-	if len(kanikoAnnotations) == 0 {
-		t.Fatalf("No annotations found for kaniko image %s", kanikoImage)
-	}
-	if diff := cmp.Diff(kanikoAnnotations, dockerAnnotations); diff != "" {
-		t.Errorf("Annotation don't match (-kaniko, +docker): %s", diff)
-	}
-
-	if kanikoAnnotations[annotationKey] != annotationValue {
-		t.Errorf("Expected annotation %q to be %q, got annotations: %v", annotationKey, annotationValue, kanikoAnnotations)
-	}
-}
-
-func getImageManifestAnnotations(t *testing.T, image string) (map[string]string, error) {
-	t.Helper()
-
-	ref, err := name.ParseReference(image, name.WeakValidation)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse image reference %s: %w", image, err)
-	}
-
-	imgRef, err := remote.Image(ref)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get image reference for %s from remote: %w", image, err)
-	}
-
-	manifest, err := imgRef.Manifest()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get manifest for image %s: %w", image, err)
-	}
-
-	return manifest.Annotations, nil
 }
 
 func onBuildDiff(t *testing.T, image1, image2 string) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -764,8 +764,6 @@ func TestWarmer(t *testing.T) {
 			kanikoVersion1 := GetKanikoImage(imageRepo, "test_warmer_"+dockerfile) + strconv.Itoa(1)
 
 			containerDiff(t, kanikoVersion0, kanikoVersion1)
-			layerDiff(t, kanikoVersion0, kanikoVersion1)
-			manifestDiff(t, kanikoVersion0, kanikoVersion1)
 		})
 	}
 }
@@ -845,7 +843,6 @@ func verifyBuildWith(t *testing.T, cache, dockerfile string) {
 	kanikoVersion1 := GetVersionedKanikoImage(config.imageRepo, dockerfile, 1)
 
 	containerDiff(t, kanikoVersion0, kanikoVersion1)
-	layerDiff(t, kanikoVersion0, kanikoVersion1)
 }
 
 func TestRelativePaths(t *testing.T) {
@@ -1000,84 +997,6 @@ func onBuildDiff(t *testing.T, image1, image2 string) {
 	testutil.CheckDeepEqual(t, img1.Config.OnBuild, img2.Config.OnBuild)
 }
 
-func layerDiff(t *testing.T, image1, image2 string) {
-	t.Helper()
-	layers1, err := getImageLayers(image1)
-	if err != nil {
-		t.Fatalf("Couldn't get layers from image reference for (%s): %s", image1, err)
-	}
-
-	layers2, err := getImageLayers(image2)
-	if err != nil {
-		t.Fatalf("Couldn't get layers from image reference for (%s): %s", image2, err)
-	}
-
-	for idx := range min(len(layers1), len(layers2)) {
-		l1d, err := layers1[idx].Digest()
-		if err != nil {
-			t.Fatalf("Couldn't get digest from image layer (%s #%d): %s", image1, idx, err)
-		}
-
-		l2d, err := layers2[idx].Digest()
-		if err != nil {
-			t.Fatalf("Couldn't get digest from image layer (%s #%d): %s", image2, idx, err)
-		}
-
-		if l1d != l2d {
-			command, err := resolveCreatedBy(image1, idx)
-			if err != nil {
-				t.Errorf("Image Layers #%d differ", idx)
-			} else {
-				t.Errorf("Image Layers #%d differ: %s", idx, command)
-			}
-		}
-	}
-
-	if len(layers1) > len(layers2) {
-		command, err := resolveCreatedBy(image1, len(layers2))
-		if err != nil {
-			t.Errorf("Image Layer count differs %d != %d", len(layers1), len(layers2))
-		} else {
-			t.Errorf("Image Layer count differs %d != %d: %s", len(layers1), len(layers2), command)
-		}
-	} else if len(layers1) < len(layers2) {
-		command, err := resolveCreatedBy(image2, len(layers1))
-		if err != nil {
-			t.Errorf("Image Layer count differs %d != %d", len(layers1), len(layers2))
-		} else {
-			t.Errorf("Image Layer count differs %d != %d: %s", len(layers1), len(layers2), command)
-		}
-	}
-}
-
-func manifestDiff(t *testing.T, image1, image2 string) {
-	t.Helper()
-
-	imgRef1, err := getImage(image1)
-	if err != nil {
-		t.Fatalf("Couldn't get image reference for (%s): %s", image1, err)
-	}
-
-	imgRef2, err := getImage(image2)
-	if err != nil {
-		t.Fatalf("Couldn't get image reference for (%s): %s", image2, err)
-	}
-
-	media1, err := imgRef1.MediaType()
-	if err != nil {
-		t.Fatalf("Couldn't get mediatype for (%s): %s", image1, err)
-	}
-
-	media2, err := imgRef2.MediaType()
-	if err != nil {
-		t.Fatalf("Couldn't get mediatype for (%s): %s", image2, err)
-	}
-
-	if media1 != media2 {
-		t.Fatalf("mediatype diff: %s != %s", media1, media2)
-	}
-}
-
 func checkLayers(t *testing.T, image1, image2 string, offset int) {
 	t.Helper()
 	img1, err := getImageDetails(image1)
@@ -1112,42 +1031,12 @@ func getImageConfig(image string) (*v1.ConfigFile, error) {
 	return cfg, nil
 }
 
-func resolveCreatedBy(image string, layerIndex int) (string, error) {
-	cfg, err := getImageConfig(image)
-	if err != nil {
-		return "", err
-	}
-	idx := 0
-	for _, history := range cfg.History {
-		if history.EmptyLayer {
-			continue
-		}
-		if idx == layerIndex {
-			return history.CreatedBy, nil
-		}
-		idx++
-	}
-	return "", fmt.Errorf("LayerIndex %d not found in History of length %d", layerIndex, len(cfg.History))
-}
-
 func getImage(image string) (v1.Image, error) {
 	ref, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't parse reference to image %s: %w", image, err)
 	}
 	return remote.Image(ref)
-}
-
-func getImageLayers(image string) ([]v1.Layer, error) {
-	imgRef, err := getImage(image)
-	if err != nil {
-		return nil, fmt.Errorf("Couldn't get reference to image %s from remote: %w", image, err)
-	}
-	layers, err := imgRef.Layers()
-	if err != nil {
-		return nil, fmt.Errorf("Error getting layers for image %s: %w", image, err)
-	}
-	return layers, nil
 }
 
 func getImageDetails(image string) (*imageDetails, error) {

--- a/integration/k8s-job.yaml
+++ b/integration/k8s-job.yaml
@@ -12,6 +12,9 @@ spec:
         workingDir: /workspace
         args: [ "--context=dir:///workspace",
                 "--destination={{.KanikoImage}}"]
+        env:
+        - name: FF_KANIKO_NO_PROPAGATE_ANNOTATIONS
+          value: "1"
         volumeMounts:
         - name: context
           mountPath: /workspace


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Continuation of https://github.com/osscontainertools/kaniko/pull/570

Instead of normalizing all images to dockerv2 (via skopeo pull) we now accept that images can be created with both dockerv2 and ociv1 format. Kaniko per default emits whatever the mediatype of the baseimage was. buildkit per default emits ociv1, as otherwise it cannot add provenance attestations. we can force it to emit dockerv2 by disabling provenance attestations, ugly but it works.

As a benefit we now can properly see annotations in the emitted images and don't need to check on remote registry with custom functions. It still cant be merged together with TestRun as for annotations to work we need to push.

`layerDiff` is no longer required for quite a while, eversince we switched to diffoci we could have dropped that. `manifestDiff` is now no longer required as we can recognize diffs between image types.
