### PR TITLE
mz381: integration test crosstalk

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -288,10 +288,18 @@ func FindDockerFiles(dir, dockerfilesPattern string) ([]string, error) {
 	return dockerfiles, err
 }
 
+type syncMap[K comparable, V any] struct{ m sync.Map }
+
+func (s *syncMap[K, V]) LoadOrStore(key K, val V) (V, bool) {
+	v, ok := s.m.LoadOrStore(key, val)
+	return v.(V), ok
+}
+
 // DockerFileBuilder knows how to build docker files using both Kaniko and Docker and
 // keeps track of which files have been built.
 type DockerFileBuilder struct {
-	filesBuilt              sync.Map // map[string]*sync.Once
+	// Holds all available docker files and whether or not they've been built
+	filesBuilt              syncMap[string, func() error]
 	DockerfilesToIgnore     map[string]struct{}
 	TestCacheDockerfiles    map[string]struct{}
 	TestOCICacheDockerfiles map[string]struct{}
@@ -414,13 +422,10 @@ func (d *DockerFileBuilder) BuildImage(t *testing.T, config *integrationTestConf
 }
 
 func (d *DockerFileBuilder) BuildImageWithContext(t *testing.T, config *integrationTestConfig, dockerfilesPath, dockerfile, contextDir string) error {
-	val, _ := d.filesBuilt.LoadOrStore(dockerfile, &sync.Once{})
-	once := val.(*sync.Once)
-	var buildErr error
-	once.Do(func() {
-		buildErr = d.buildImage(t, config, dockerfilesPath, dockerfile, contextDir)
-	})
-	return buildErr
+	fn, _ := d.filesBuilt.LoadOrStore(dockerfile, sync.OnceValue(func() error {
+		return d.buildImage(t, config, dockerfilesPath, dockerfile, contextDir)
+	}))
+	return fn()
 }
 
 func (d *DockerFileBuilder) buildImage(t *testing.T, config *integrationTestConfig, dockerfilesPath, dockerfile, contextDir string) error {

--- a/integration/images.go
+++ b/integration/images.go
@@ -29,6 +29,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -290,6 +291,7 @@ func FindDockerFiles(dir, dockerfilesPattern string) ([]string, error) {
 // DockerFileBuilder knows how to build docker files using both Kaniko and Docker and
 // keeps track of which files have been built.
 type DockerFileBuilder struct {
+	mu sync.Mutex
 	// Holds all available docker files and whether or not they've been built
 	filesBuilt              map[string]struct{}
 	DockerfilesToIgnore     map[string]struct{}
@@ -416,7 +418,10 @@ func (d *DockerFileBuilder) BuildImage(t *testing.T, config *integrationTestConf
 }
 
 func (d *DockerFileBuilder) BuildImageWithContext(t *testing.T, config *integrationTestConfig, dockerfilesPath, dockerfile, contextDir string) error {
-	if _, present := d.filesBuilt[dockerfile]; present {
+	d.mu.Lock()
+	_, present := d.filesBuilt[dockerfile]
+	d.mu.Unlock()
+	if present {
 		return nil
 	}
 	gcsBucket, gcsClient, serviceAccount, imageRepo := config.gcsBucket, config.gcsClient, config.serviceAccount, config.imageRepo
@@ -458,7 +463,9 @@ func (d *DockerFileBuilder) BuildImageWithContext(t *testing.T, config *integrat
 	}
 	timing.DefaultRun.Stop(timer)
 
+	d.mu.Lock()
 	d.filesBuilt[dockerfile] = struct{}{}
+	d.mu.Unlock()
 
 	return nil
 }

--- a/integration/images.go
+++ b/integration/images.go
@@ -291,9 +291,7 @@ func FindDockerFiles(dir, dockerfilesPattern string) ([]string, error) {
 // DockerFileBuilder knows how to build docker files using both Kaniko and Docker and
 // keeps track of which files have been built.
 type DockerFileBuilder struct {
-	mu sync.Mutex
-	// Holds all available docker files and whether or not they've been built
-	filesBuilt              map[string]struct{}
+	filesBuilt              sync.Map // map[string]*sync.Once
 	DockerfilesToIgnore     map[string]struct{}
 	TestCacheDockerfiles    map[string]struct{}
 	TestOCICacheDockerfiles map[string]struct{}
@@ -305,9 +303,7 @@ type logger func(string, ...any)
 // NewDockerFileBuilder will create a DockerFileBuilder initialized with dockerfiles, which
 // it will assume are all as yet unbuilt.
 func NewDockerFileBuilder() *DockerFileBuilder {
-	d := DockerFileBuilder{
-		filesBuilt: map[string]struct{}{},
-	}
+	d := DockerFileBuilder{}
 	d.DockerfilesToIgnore = map[string]struct{}{
 		"Dockerfile_test_add_404": {},
 		// TODO: remove test_user_run from this when https://github.com/GoogleContainerTools/container-diff/issues/237 is fixed
@@ -418,12 +414,16 @@ func (d *DockerFileBuilder) BuildImage(t *testing.T, config *integrationTestConf
 }
 
 func (d *DockerFileBuilder) BuildImageWithContext(t *testing.T, config *integrationTestConfig, dockerfilesPath, dockerfile, contextDir string) error {
-	d.mu.Lock()
-	_, present := d.filesBuilt[dockerfile]
-	d.mu.Unlock()
-	if present {
-		return nil
-	}
+	val, _ := d.filesBuilt.LoadOrStore(dockerfile, &sync.Once{})
+	once := val.(*sync.Once)
+	var buildErr error
+	once.Do(func() {
+		buildErr = d.buildImage(t, config, dockerfilesPath, dockerfile, contextDir)
+	})
+	return buildErr
+}
+
+func (d *DockerFileBuilder) buildImage(t *testing.T, config *integrationTestConfig, dockerfilesPath, dockerfile, contextDir string) error {
 	gcsBucket, gcsClient, serviceAccount, imageRepo := config.gcsBucket, config.gcsClient, config.serviceAccount, config.imageRepo
 
 	var buildArgs []string
@@ -462,10 +462,6 @@ func (d *DockerFileBuilder) BuildImageWithContext(t *testing.T, config *integrat
 		return err
 	}
 	timing.DefaultRun.Stop(timer)
-
-	d.mu.Lock()
-	d.filesBuilt[dockerfile] = struct{}{}
-	d.mu.Unlock()
 
 	return nil
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -169,6 +169,7 @@ func buildRequiredImages() error {
 }
 
 func TestRun(t *testing.T) {
+	t.Parallel()
 	for _, dockerfile := range allDockerfiles {
 		t.Run("test_"+dockerfile, func(t *testing.T) {
 			dockerfile := dockerfile
@@ -580,6 +581,7 @@ func TestBuildWithHTTPError(t *testing.T) {
 }
 
 func TestLayers(t *testing.T) {
+	t.Parallel()
 	// offset is caused because for those three files we use
 	// --single-snapshot option, compressing all layers into one
 	offset := map[string]int{
@@ -615,6 +617,7 @@ func TestLayers(t *testing.T) {
 }
 
 func TestReplaceFolderWithFileOrLink(t *testing.T) {
+	t.Parallel()
 	dockerfiles := []string{"TestReplaceFolderWithFile", "TestReplaceFolderWithLink"}
 	for _, dockerfile := range dockerfiles {
 		t.Run(dockerfile, func(t *testing.T) {
@@ -648,6 +651,7 @@ func buildImage(t *testing.T, dockerfile string, imageBuilder *DockerFileBuilder
 
 // Build each image with kaniko twice, and then make sure they're exactly the same
 func TestCache(t *testing.T) {
+	t.Parallel()
 	// Build dockerfiles with registry cache
 	for dockerfile := range imageBuilder.TestCacheDockerfiles {
 		t.Run("test_cache_"+dockerfile, func(t *testing.T) {
@@ -674,6 +678,7 @@ func TestCache(t *testing.T) {
 }
 
 func TestWarmer(t *testing.T) {
+	t.Parallel()
 	populateVolumeCache(t.Logf, config.serviceAccount)
 
 	for dockerfile := range imageBuilder.TestWarmerDockerfiles {
@@ -708,6 +713,7 @@ func TestWarmer(t *testing.T) {
 
 // Attempt to warm an image two times : first time should populate the cache, second time should find the image in the cache.
 func TestWarmerTwice(t *testing.T) {
+	t.Parallel()
 	dockerfiles := map[string]bool{
 		"debian:trixie-slim": true,
 		"debian:12.10@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56": true,  // image-index requires remote lookup
@@ -785,6 +791,7 @@ func verifyBuildWith(t *testing.T, cache, dockerfile string) {
 }
 
 func TestRelativePaths(t *testing.T) {
+	t.Parallel()
 	dockerfile := "Dockerfile_relative_copy"
 
 	t.Run("test_relative_"+dockerfile, func(t *testing.T) {
@@ -813,6 +820,7 @@ func TestRelativePaths(t *testing.T) {
 }
 
 func TestExitCodePropagation(t *testing.T) {
+	t.Parallel()
 	currentDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal("Could not get working dir")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -239,12 +239,12 @@ func KanikoGitRepo(url string, commit string, branch string) string {
 	return fmt.Sprintf("git://%s.git%s", url, ref)
 }
 
-func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch string) {
+func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch string, imageName string) {
 	t.Log("testGitBuildcontextHelper repo", url)
 	dockerfile := fmt.Sprintf("%s/%s/Dockerfile_test_run_2", integrationPath, dockerfilesPath)
 
 	// Build with docker
-	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_git")
+	dockerImage := GetDockerImage(config.imageRepo, imageName)
 	dockerCmd := exec.Command("docker",
 		[]string{
 			"build",
@@ -259,7 +259,7 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 	}
 
 	// Build with kaniko
-	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_git")
+	kanikoImage := GetKanikoImage(config.imageRepo, imageName)
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
@@ -284,7 +284,7 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 func TestGitBuildcontext(t *testing.T) {
 	t.Parallel()
 	branch, _, url := getBranchCommitAndURL()
-	testGitBuildcontextHelper(t, url, "", branch)
+	testGitBuildcontextHelper(t, url, "", branch, "Dockerfile_test_git_branch")
 }
 
 // TestGitBuildcontextNoRef builds without any commit / branch reference
@@ -295,7 +295,7 @@ func TestGitBuildcontextNoRef(t *testing.T) {
 	t.Skip("Docker's behavior is to assume a 'master' branch, which the Kaniko repo doesn't have")
 	t.Parallel()
 	_, _, url := getBranchCommitAndURL()
-	testGitBuildcontextHelper(t, url, "", "")
+	testGitBuildcontextHelper(t, url, "", "", "Dockerfile_test_git_noref")
 }
 
 // TestGitBuildcontextExplicitCommit uses an explicit commit hash instead of named reference
@@ -305,7 +305,7 @@ func TestGitBuildcontextNoRef(t *testing.T) {
 func TestGitBuildcontextExplicitCommit(t *testing.T) {
 	t.Parallel()
 	_, commit, url := getBranchCommitAndURL()
-	testGitBuildcontextHelper(t, url, commit, "")
+	testGitBuildcontextHelper(t, url, commit, "", "Dockerfile_test_git_commit")
 }
 
 func TestGitBuildcontextSubPath(t *testing.T) {
@@ -314,7 +314,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	dockerfile := "Dockerfile_test_run_2"
 
 	// Build with docker
-	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_git")
+	dockerImage := GetDockerImage(config.imageRepo, "Dockerfile_test_git_subpath")
 	dockerCmd := exec.Command("docker",
 		[]string{
 			"build",
@@ -329,7 +329,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	}
 
 	// Build with kaniko
-	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_git")
+	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_git_subpath")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = append(

--- a/integration/integration_with_stdin_test.go
+++ b/integration/integration_with_stdin_test.go
@@ -51,11 +51,7 @@ func TestBuildWithStdin(t *testing.T) {
 		t.Errorf("Failed to setup files %v on %s: %v", files, testDir, err)
 	}
 
-	if err := os.Chdir(testDir); err != nil {
-		t.Fatalf("Failed to Chdir on %s: %v", testDir, err)
-	}
-
-	tarPath := dockerfile + ".tar.gz"
+	tarPath := filepath.Join(testDirLongPath, dockerfile+".tar.gz")
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -74,7 +70,7 @@ func TestBuildWithStdin(t *testing.T) {
 		tw := util.NewTar(gw)
 		defer tw.Close()
 
-		if err := tw.AddFileToTar(dockerfile); err != nil {
+		if err := tw.AddFileToTar(filepath.Join(testDirLongPath, dockerfile)); err != nil {
 			t.Errorf("Failed to add %s to %s: %v", dockerfile, tarPath, err)
 		}
 	}(&wg)
@@ -93,6 +89,7 @@ func TestBuildWithStdin(t *testing.T) {
 			"-f", dockerfile,
 			".",
 		}...)
+	dockerCmd.Dir = testDirLongPath
 
 	_, err := RunCommandWithoutTest(dockerCmd)
 	if err != nil {
@@ -102,6 +99,7 @@ func TestBuildWithStdin(t *testing.T) {
 	// Build with kaniko using Stdin
 	kanikoImage := GetKanikoImage(config.imageRepo, dockerfile)
 	tarCmd := exec.Command("tar", "-cf", "-", dockerfile)
+	tarCmd.Dir = testDirLongPath
 	gzCmd := exec.Command("gzip", "-9")
 
 	dockerRunFlags := []string{"run", "--interactive", "--net=host", "-v", cwd + ":/workspace"}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/381

**Description**
Now that we push images to registry, name conflicts on tags become more obvious. With this change we fix some of the obvious name conflicts. we should add an assertion that no conflicts are introduced. AI static analysis found some further ones:


```
  ┌────────────────────────────┬───────────────────────────────────┬────────────────────────────────────────┐
  │         Dockerfile         │          Used by TestRun          │      Also used by standalone test      │
  ├────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────┤
  │ Dockerfile_registry_mirror │ docker-dockerfile_registry_mirror │ TestBuildViaRegistryMirrors (parallel) │
  ├────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────┤
  │ Dockerfile_test_label      │ docker-dockerfile_test_label      │ TestBuildWithLabels (parallel)         │
  ├────────────────────────────┼───────────────────────────────────┼────────────────────────────────────────┤
  │ Dockerfile_test_add_404    │ docker-dockerfile_test_add_404    │ TestBuildWithHTTPError (parallel)      │
  └────────────────────────────┴───────────────────────────────────┴────────────────────────────────────────┘
```

but they shouldnt clash in CI as they run in different workers



**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
