### PR TITLE
3319: oci scratch base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_COPY_CHMOD_ON_IMPLICIT_DIRS`](#flag-ff_kaniko_copy_chmod_on_implicit_dirs)
       - [Flag `FF_KANIKO_CLEAN_KANIKO_DIR`](#flag-ff_kaniko_clean_kaniko_dir)
       - [Flag `FF_KANIKO_NO_PROPAGATE_ANNOTATIONS`](#flag-ff_kaniko_no_propagate_annotations)
+      - [Flag `FF_KANIKO_OCI_SCRATCH_BASE`](#flag-ff_kaniko_oci_scratch_base)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1135,6 +1136,12 @@ Defaults to `true`.
 When building from a base image that carries OCI manifest annotations (e.g. `org.opencontainers.image.url`, `org.opencontainers.image.version`), kaniko by default propagates those annotations into the output image manifest. This differs from Docker/BuildKit behaviour, which does not carry base image annotations forward into derived images.
 Set this flag to `true` to strip base image manifest annotations from the output, matching Docker behaviour. Defaults to `false`.
 Becomes default in `v1.28.0`.
+
+#### Flag `FF_KANIKO_OCI_SCRATCH_BASE`
+
+When a Dockerfile uses `FROM scratch`, kaniko uses an empty Docker-format image as the build base, which means the output image is produced in Docker manifest schema v2 format.
+Set this flag to `true` to use an empty OCI-format image instead, causing `FROM scratch` builds to produce output in OCI manifest schema v1 format. Defaults to `false`.
+Currently no plans to activate.
 
 ### Debug Image
 

--- a/integration/images.go
+++ b/integration/images.go
@@ -97,6 +97,7 @@ var KanikoEnv = []string{
 	"FF_KANIKO_RUN_VIA_TINI=1",
 	"FF_KANIKO_COPY_CHMOD_ON_IMPLICIT_DIRS=1",
 	"FF_KANIKO_NO_PROPAGATE_ANNOTATIONS=1",
+	"FF_KANIKO_OCI_SCRATCH_BASE=1",
 }
 
 var WarmerEnv = []string{
@@ -105,35 +106,27 @@ var WarmerEnv = []string{
 
 // Arguments to build Dockerfiles with when building with docker
 var additionalDockerFlagsMap = map[string][]string{
-	"Dockerfile_test_target":      {"--target=second", "--provenance=false"},
+	"Dockerfile_test_target":      {"--target=second"},
 	"Dockerfile_test_issue_cg188": {"--secret=id=netrc,env=SECRET"},
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=context/foo"},
 	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
 	"Dockerfile_test_mv_add":                       {"--provenance=false"},
 	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},
-	"Dockerfile_test_workdir_with_user":            {"--provenance=false"},
 	"Dockerfile_test_whitelist":                    {"--provenance=false"},
 	"Dockerfile_test_volume_4":                     {"--provenance=false"},
 	"Dockerfile_test_volume_3":                     {"--provenance=false"},
-	"Dockerfile_test_maintainer":                   {"--provenance=false"},
 	"Dockerfile_test_meta_arg":                     {"--provenance=false"},
 	"Dockerfile_test_replaced_symlinks":            {"--provenance=false"},
-	"Dockerfile_test_scratch":                      {"--provenance=false"},
 	"Dockerfile_test_registry":                     {"--provenance=false"},
 	"Dockerfile_test_pre_defined_build_args":       {"--provenance=false"},
 	"Dockerfile_test_replaced_hardlinks":           {"--provenance=false"},
 	"Dockerfile_test_issue_647":                    {"--provenance=false"},
 	"Dockerfile_test_copy_root_multistage":         {"--provenance=false"},
-	"Dockerfile_test_issue_1965":                   {"--provenance=false"},
-	"Dockerfile_test_issue_1007":                   {"--provenance=false"},
-	"Dockerfile_test_ignore":                       {"--provenance=false"},
 	"Dockerfile_test_issue_1837":                   {"--provenance=false"},
 	"Dockerfile_test_issue_2049":                   {"--provenance=false"},
-	"Dockerfile_test_dockerignore":                 {"--provenance=false"},
 	"Dockerfile_test_issue_1039":                   {"--provenance=false"},
 	"Dockerfile_test_dangling_symlink":             {"--provenance=false"},
 	"Dockerfile_test_copyadd_chmod":                {"--provenance=false"},
-	"Dockerfile_test_copy_symlink":                 {"--provenance=false"},
 	"Dockerfile_test_copy_same_file_many_times":    {"--provenance=false"},
 	"Dockerfile_test_copy_reproducible":            {"--provenance=false"},
 	"Dockerfile_test_copy_chown_intermediate_dirs": {"--provenance=false"},

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -654,7 +654,7 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
 		if s.BaseImageStoredLocally {
 			image = images[s.BaseImageIndex]
 		} else if s.Name == constants.NoBaseImage {
-			image = empty.Image
+			image = image_util.EmptyBaseImage
 		} else {
 			image, err = image_util.RetrieveSourceImage(s, opts)
 			if err != nil {

--- a/pkg/image/image_util.go
+++ b/pkg/image/image_util.go
@@ -26,7 +26,9 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/osscontainertools/kaniko/pkg/cache"
 	"github.com/osscontainertools/kaniko/pkg/config"
@@ -39,8 +41,18 @@ import (
 
 var (
 	// RetrieveRemoteImage downloads an image from a remote location
-	RetrieveRemoteImage = remote.RetrieveRemoteImage
-	retrieveOciImage    = ociImage
+	RetrieveRemoteImage          = remote.RetrieveRemoteImage
+	retrieveOciImage             = ociImage
+	EmptyBaseImage      v1.Image = func() v1.Image {
+		image := empty.Image
+		if config.EnvBool("FF_KANIKO_OCI_SCRATCH_BASE") {
+			image = mutate.ConfigMediaType(
+				mutate.MediaType(image, types.OCIManifestSchema1),
+				types.OCIConfigJSON,
+			)
+		}
+		return image
+	}()
 )
 
 // RetrieveSourceImage returns the base image of the stage at index
@@ -66,7 +78,7 @@ func RetrieveSourceImageInternal(baseName string, baseImageStoredLocally bool, b
 	// First, check if the base image is a scratch image
 	if currentBaseName == constants.NoBaseImage {
 		logrus.Info("No base image, nothing to extract")
-		return empty.Image, nil
+		return EmptyBaseImage, nil
 	}
 	// Next, check if the base image of the current stage is built from a previous stage
 	// If so, retrieve the image from the stored tarball


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/GoogleContainerTools/kaniko/issues/3319

**Description**

kaniko output mediatype depends on input mediatype, for `FROM scratch` we always go with dockerv2, so they can never be emitted as ociv1. Introduces a new featureflag that defaults to ociv1 for empty images. We should add a cli arg to actually give full control over the output type instead, but it is a start.
