### PR TITLE
mz334: infer crossstage cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_VOLUME_SKIP_MKDIR`](#flag-ff_kaniko_volume_skip_mkdir)
       - [Flag `FF_KANIKO_PRESERVE_HARDLINKS`](#flag-ff_kaniko_preserve_hardlinks)
       - [Flag `FF_KANIKO_BUILDKIT_ARG_ENV_PRECEDENCE`](#flag-ff_kaniko_buildkit_arg_env_precedence)
+      - [Flag `FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY`](#flag-ff_kaniko_infer_cross_stage_cache_key)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1175,6 +1176,13 @@ RUN echo $HELLO   # prints the --build-arg value, not "upstream"
 ```
 
 Set this flag to `true` to enable BuildKit-compatible ARG/ENV precedence. Defaults to `false`.
+Becomes default in `v1.28.0`.
+
+#### Flag `FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY`
+
+When a multi-stage build uses `COPY --from=<stage>` and the source stage has a 100% cache hit, kaniko still unpacks the source stage's filesystem in order to hash the copied files and compute the downstream cache key, as the cache key is content addressed. But if a source stage is fully cached, its `finalCacheKey` can be used as a stable proxy for the file contents, so the downstream cache key can be computed without accessing the filesystem at all. This is a preparatory optimisation for a future change that will avoid unpacking the source stage's filesystem entirely when all downstream stages are also fully cached.
+Set this flag to `true` to add additional cache entries for the shortcuts, currently they do not yet allow optimization.
+Requires `--cache-copy-layers`. Defaults to `false`.
 Becomes default in `v1.28.0`.
 
 ### Debug Image

--- a/README.md
+++ b/README.md
@@ -1180,7 +1180,7 @@ Becomes default in `v1.28.0`.
 
 #### Flag `FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY`
 
-When a multi-stage build uses `COPY --from=<stage>` and the source stage has a 100% cache hit, kaniko still unpacks the source stage's filesystem in order to hash the copied files and compute the downstream cache key, as the cache key is content addressed. But if a source stage is fully cached, its `finalCacheKey` can be used as a stable proxy for the file contents, so the downstream cache key can be computed without accessing the filesystem at all. This is a preparatory optimisation for a future change that will avoid unpacking the source stage's filesystem entirely when all downstream stages are also fully cached.
+When a multi-stage build uses `COPY --from=<stage>`, kaniko normally hashes the copied files from the source stage's filesystem to compute the downstream cache key. The source stage's `finalCacheKey` is a deterministic function of its build inputs and can be used as a stable proxy for those file contents, so the downstream cache key can be inferred without accessing the filesystem at all. This is a preparatory optimisation for a future change that will avoid unpacking the source stage's filesystem entirely when all downstream stages are also fully cached.
 Set this flag to `true` to add additional cache entries for the shortcuts, currently they do not yet allow optimization.
 Requires `--cache-copy-layers`. Defaults to `false`.
 Becomes default in `v1.28.0`.

--- a/integration/dockerfiles/Dockerfile_test_issue_mz334
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz334
@@ -1,0 +1,14 @@
+FROM busybox AS first
+RUN touch /bli
+RUN touch /blubb
+
+FROM first AS second
+RUN touch /bla
+
+FROM second AS third
+RUN touch /bli
+
+FROM second AS final
+COPY --from=first /blubb /blubb
+COPY --from=third /bli /bli
+RUN ls -lah /blubb

--- a/integration/images.go
+++ b/integration/images.go
@@ -89,6 +89,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_mz473":                {"KANIKO_DIR=/kaniko2"},
 	"Dockerfile_test_issue_mz511":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz529":                {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_mz334":                {"FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY=1"},
 }
 
 var KanikoEnv = []string{
@@ -163,6 +164,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_maintainer":             {"--single-snapshot"},
 	"Dockerfile_test_target":                 {"--target=second"},
 	"Dockerfile_test_snapshotter_ignorelist": {"--use-new-run=true", "-v=trace"},
+	"Dockerfile_test_issue_mz334":            {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache":                  {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache_oci":              {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache_install":          {"--cache-copy-layers=true"},
@@ -238,6 +240,20 @@ var outputChecks = map[string]func(string, []byte) error{
 			}
 		}
 
+		return nil
+	},
+}
+
+var cacheHitOutputChecks = map[string]func(string, []byte) error{
+	"Dockerfile_test_issue_mz334": func(_ string, out []byte) error {
+		for _, cmd := range []string{
+			"COPY --from=first /blubb /blubb",
+			"COPY --from=third /bli /bli",
+		} {
+			if !strings.Contains(string(out), "Cache hit via inferred cross-stage key for cmd: "+cmd) {
+				return fmt.Errorf("expected inferred-key cache hit for %q but found none in output", cmd)
+			}
+		}
 		return nil
 	},
 }
@@ -376,6 +392,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_add":     {},
 		"Dockerfile_test_issue_empty":   {},
 		"Dockerfile_test_issue_mz637":   {},
+		"Dockerfile_test_issue_mz334":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{
 		"Dockerfile_test_cache_oci":         {},
@@ -591,6 +608,9 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	for _, envVariable := range KanikoEnv {
 		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
+	for _, envVariable := range envsMap[dockerfile] {
+		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
+	}
 	executorImage := ExecutorImage
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
@@ -615,6 +635,13 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	if outputCheck := outputChecks[dockerfile]; outputCheck != nil {
 		if err := outputCheck(dockerfile, out); err != nil {
 			return fmt.Errorf("output check failed for image %s with kaniko command : %w", kanikoImage, err)
+		}
+	}
+	if version > 0 {
+		if outputCheck := cacheHitOutputChecks[dockerfile]; outputCheck != nil {
+			if err := outputCheck(dockerfile, out); err != nil {
+				return fmt.Errorf("cache hit check failed for image %s: %w", kanikoImage, err)
+			}
 		}
 	}
 	if outputCheck := warmerOutputChecks[dockerfile]; outputCheck != nil {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -307,6 +307,12 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 			}
 
 			if cacheCmd := command.CacheCommand(img); cacheCmd != nil {
+				// mz334: add a log s.t. it becomes integration test testable
+				if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") {
+					if _, ok := crossStageCacheKey(command, stageFinalCacheKeys); ok {
+						logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
+					}
+				}
 				logrus.Infof("Using caching version of cmd: %s", command.String())
 				s.cmds[i] = cacheCmd
 			}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -206,7 +206,20 @@ func isOCILayout(path string) bool {
 	return strings.HasPrefix(path, "oci:")
 }
 
-func populateCompositeKey(command commands.DockerCommand, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string, fileContext util.FileContext, stageDiffIDs map[int]string) (CompositeCache, error) {
+func crossStageCacheKey(command commands.DockerCommand, stageFinalCacheKeys map[int]string) (string, bool) {
+	copyCmd, ok := commands.CastAbstractCopyCommand(command)
+	if !ok || copyCmd.From() == "" {
+		return "", false
+	}
+	fromIdx, err := strconv.Atoi(copyCmd.From())
+	if err != nil {
+		return "", false
+	}
+	cacheKey, ok := stageFinalCacheKeys[fromIdx]
+	return cacheKey, ok
+}
+
+func populateCompositeKey(command commands.DockerCommand, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string, fileContext util.FileContext, stageFinalCacheKeys map[int]string) (CompositeCache, error) {
 	// First replace all the environment variables or args in the command
 	replacementEnvs := args.ReplacementEnvs(env)
 	// The sort order of `replacementEnvs` is basically undefined, sort it
@@ -227,12 +240,12 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	// Add the next command to the cache key.
 	compositeKey.AddKey(command.String())
 
-	if copyCmd, ok := commands.CastAbstractCopyCommand(command); ok && copyCmd.From() != "" {
-		if fromIdx, err := strconv.Atoi(copyCmd.From()); err == nil {
-			if cacheKey, ok := stageDiffIDs[fromIdx]; ok {
-				compositeKey.AddKey(cacheKey)
-				return compositeKey, nil
-			}
+	// mz334: COPY --from shortcut — use the source stage's cache key instead of hashing files.
+	if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") {
+		cacheKey, ok := crossStageCacheKey(command, stageFinalCacheKeys)
+		if ok {
+			compositeKey.AddKey(cacheKey)
+			return compositeKey, nil
 		}
 	}
 
@@ -244,7 +257,7 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	return compositeKey, nil
 }
 
-func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, stageDiffIDs map[int]string) (string, bool, error) {
+func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, stageFinalCacheKeys map[int]string) (string, bool, error) {
 	if !opts.Cache {
 		return "", false, nil
 	}
@@ -269,7 +282,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 			return "", false, fmt.Errorf("failed to get files used from context: %w", err)
 		}
 
-		compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, cfg.Env, fileContext, stageDiffIDs)
+		compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, cfg.Env, fileContext, stageFinalCacheKeys)
 		if err != nil {
 			return "", false, err
 		}
@@ -309,7 +322,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 	return finalCacheKey, !stopCache, nil
 }
 
-func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageDiffIDs map[int]string) error {
+func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageFinalCacheKeys map[int]string) error {
 	// Unpack file system to root if we need to.
 	shouldUnpack := false
 	for _, cmd := range s.cmds {
@@ -371,7 +384,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		}
 
 		if opts.Cache {
-			compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext, stageDiffIDs)
+			compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext, stageFinalCacheKeys)
 			if err != nil {
 				return err
 			}
@@ -786,7 +799,10 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	t := timing.Start("Total Build Time")
 	digestToCacheKey := make(map[string]string)
-	stageDiffIDs := make(map[int]string)
+
+	// mz334: when FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY is set, a fully-cached
+	// stage's finalCacheKey is used as a proxy for COPY --from= file hashing.
+	stageFinalCacheKeys := make(map[int]string)
 
 	stages, metaArgs, err := dockerfile.ParseStages(opts)
 	if err != nil {
@@ -902,15 +918,14 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		}
 
 		// Apply optimizations to the instructions.
-		layerCache := newLayerCache(opts)
-		finalCacheKey, fullyCached, err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, layerCache, stageDiffIDs)
+		finalCacheKey, fullyCached, err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts), stageFinalCacheKeys)
 		if err != nil {
 			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
 		}
 
 		stageArgs[stage.Index] = sb.args
 		crossStageDeps := len(crossStageDependencies[stage.Index]) > 0
-		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps, stageDiffIDs)
+		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps, stageFinalCacheKeys)
 		if err != nil {
 			return nil, fmt.Errorf("error building stage: %w", err)
 		}
@@ -951,8 +966,8 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		digestToCacheKey[d.String()] = finalCacheKey
 		logrus.Debugf("Mapping digest %v to cachekey %v", d.String(), finalCacheKey)
 
-		if fullyCached && opts.Cache {
-			stageDiffIDs[stage.Index] = finalCacheKey
+		if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && fullyCached && opts.Cache && opts.CacheCopyLayers {
+			stageFinalCacheKeys[stage.Index] = finalCacheKey
 		}
 
 		if stage.Push {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -206,7 +206,7 @@ func isOCILayout(path string) bool {
 	return strings.HasPrefix(path, "oci:")
 }
 
-func populateCompositeKey(command commands.DockerCommand, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string, fileContext util.FileContext) (CompositeCache, error) {
+func populateCompositeKey(command commands.DockerCommand, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string, fileContext util.FileContext, stageDiffIDs map[int]string) (CompositeCache, error) {
 	// First replace all the environment variables or args in the command
 	replacementEnvs := args.ReplacementEnvs(env)
 	// The sort order of `replacementEnvs` is basically undefined, sort it
@@ -227,6 +227,15 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	// Add the next command to the cache key.
 	compositeKey.AddKey(command.String())
 
+	if copyCmd, ok := commands.CastAbstractCopyCommand(command); ok && copyCmd.From() != "" {
+		if fromIdx, err := strconv.Atoi(copyCmd.From()); err == nil {
+			if cacheKey, ok := stageDiffIDs[fromIdx]; ok {
+				compositeKey.AddKey(cacheKey)
+				return compositeKey, nil
+			}
+		}
+	}
+
 	for _, f := range files {
 		if err := compositeKey.AddPath(f, fileContext); err != nil {
 			return compositeKey, err
@@ -235,9 +244,9 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	return compositeKey, nil
 }
 
-func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache) (string, error) {
+func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, stageDiffIDs map[int]string) (string, bool, error) {
 	if !opts.Cache {
-		return "", nil
+		return "", false, nil
 	}
 	buildArgs := s.args.Clone()
 	// Restore build args back to their original values
@@ -257,18 +266,18 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 		}
 		files, err := command.FilesUsedFromContext(&cfg, s.args)
 		if err != nil {
-			return "", fmt.Errorf("failed to get files used from context: %w", err)
+			return "", false, fmt.Errorf("failed to get files used from context: %w", err)
 		}
 
-		compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, cfg.Env, fileContext)
+		compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, cfg.Env, fileContext, stageDiffIDs)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 
 		logrus.Debugf("Optimize: composite key for command %v %v", command.String(), compositeKey)
 		ck, err := compositeKey.Hash()
 		if err != nil {
-			return "", fmt.Errorf("failed to hash composite key: %w", err)
+			return "", false, fmt.Errorf("failed to hash composite key: %w", err)
 		}
 
 		logrus.Debugf("Optimize: cache key for command %v %v", command.String(), ck)
@@ -293,14 +302,14 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 		// Mutate the config for any commands that require it.
 		if command.MetadataOnly() {
 			if err := command.ExecuteCommand(&cfg, s.args); err != nil {
-				return "", err
+				return "", false, err
 			}
 		}
 	}
-	return finalCacheKey, nil
+	return finalCacheKey, !stopCache, nil
 }
 
-func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool) error {
+func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageDiffIDs map[int]string) error {
 	// Unpack file system to root if we need to.
 	shouldUnpack := false
 	for _, cmd := range s.cmds {
@@ -362,7 +371,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		}
 
 		if opts.Cache {
-			compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext)
+			compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext, stageDiffIDs)
 			if err != nil {
 				return err
 			}
@@ -777,6 +786,7 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	t := timing.Start("Total Build Time")
 	digestToCacheKey := make(map[string]string)
+	stageDiffIDs := make(map[int]string)
 
 	stages, metaArgs, err := dockerfile.ParseStages(opts)
 	if err != nil {
@@ -892,14 +902,15 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		}
 
 		// Apply optimizations to the instructions.
-		finalCacheKey, err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts))
+		layerCache := newLayerCache(opts)
+		finalCacheKey, fullyCached, err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, layerCache, stageDiffIDs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
 		}
 
 		stageArgs[stage.Index] = sb.args
 		crossStageDeps := len(crossStageDependencies[stage.Index]) > 0
-		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps)
+		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps, stageDiffIDs)
 		if err != nil {
 			return nil, fmt.Errorf("error building stage: %w", err)
 		}
@@ -939,6 +950,10 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 		digestToCacheKey[d.String()] = finalCacheKey
 		logrus.Debugf("Mapping digest %v to cachekey %v", d.String(), finalCacheKey)
+
+		if fullyCached && opts.Cache {
+			stageDiffIDs[stage.Index] = finalCacheKey
+		}
 
 		if stage.Push {
 			sourceImage, err = mutate.CreatedAt(sourceImage, v1.Time{Time: time.Now()})

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -59,6 +59,7 @@ var (
 	getFSFromImage               = util.GetFSFromImage
 	mkdirPermissions os.FileMode = 0o755
 	pushCache                    = pushLayerToCache
+	pushPointer                  = pushCachePointer
 )
 
 type snapShotter interface {
@@ -264,6 +265,24 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	return compositeKey, nil
 }
 
+func redirectCacheKey(inferredKey CompositeCache, layerCache cache.LayerCache) (*CompositeCache, error) {
+	inferredCk, err := inferredKey.Hash()
+	if err != nil {
+		return nil, err
+	}
+	ptrImg, err := layerCache.RetrieveLayer(inferredCk)
+	if err != nil {
+		logrus.Debugf("Failed to retrieve pointer: %s", err)
+		logrus.Debugf("Key missing was: %s", inferredKey.Key())
+		return nil, nil
+	}
+	rawKey, ok := resolveCachePointer(ptrImg)
+	if !ok {
+		return nil, fmt.Errorf("failed resolving cache pointer")
+	}
+	return NewCompositeCache(rawKey), nil
+}
+
 func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, stageFinalCacheKeys map[int]string) (string, error) {
 	if !opts.Cache {
 		return "", nil
@@ -295,6 +314,32 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 			return "", err
 		}
 
+		// mz334: assert the inferred key pointer resolves to the same content key.
+		if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
+			inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, s.args, cfg.Env, fileContext, stageFinalCacheKeys)
+			if err == nil {
+				contentKey, err := redirectCacheKey(inferredKey, layerCache)
+				if err != nil {
+					return "", err
+				}
+				if contentKey != nil {
+					ick, err := contentKey.Hash()
+					if err != nil {
+						return "", err
+					}
+					ck, err := compositeKey.Hash()
+					if err != nil {
+						return "", err
+					}
+					if ick != ck {
+						logrus.Panicf("Unreachable Code: pointer inferred content key %v does not match the computed content key %v", ick, ck)
+					}
+					// mz334: log when the inferred key produced the hit (integration test observability only).
+					logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
+				}
+			}
+		}
+
 		logrus.Debugf("Optimize: composite key for command %v %v", command.String(), compositeKey)
 		ck, err := compositeKey.Hash()
 		if err != nil {
@@ -305,28 +350,9 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 		finalCacheKey = ck
 
 		if command.ShouldCacheOutput() && !stopCache {
-			var img v1.Image
-			lookupErr := fmt.Errorf("no cache lookup attempted")
-
-			// mz334: When FF is enabled, try the inferred key first so we can observe
-			// and log inferred-key hits (integration test observability).
-			if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
-				inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, s.args, cfg.Env, fileContext, stageFinalCacheKeys)
-				if err == nil {
-					inferredCk, err := inferredKey.Hash()
-					if err == nil && inferredCk != ck {
-						img, lookupErr = layerCache.RetrieveLayer(inferredCk)
-					}
-				}
-			}
-
-			usedInferredKey := lookupErr == nil
-			if lookupErr != nil {
-				img, lookupErr = layerCache.RetrieveLayer(ck)
-			}
-
-			if lookupErr != nil {
-				logrus.Debugf("Failed to retrieve layer: %s", lookupErr)
+			img, err := layerCache.RetrieveLayer(ck)
+			if err != nil {
+				logrus.Debugf("Failed to retrieve layer: %s", err)
 				logrus.Infof("No cached layer found for cmd %s", command.String())
 				logrus.Debugf("Key missing was: %s", compositeKey.Key())
 				stopCache = true
@@ -334,10 +360,6 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 			}
 
 			if cacheCmd := command.CacheCommand(img); cacheCmd != nil {
-				// mz334: log when the inferred key produced the hit (integration test observability only).
-				if usedInferredKey {
-					logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
-				}
 				logrus.Infof("Using caching version of cmd: %s", command.String())
 				s.cmds[i] = cacheCmd
 			}
@@ -421,7 +443,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			if err != nil {
 				return err
 			}
-			// mz334: also compute the inferred key so we can push under both keys below.
+			// mz334: also compute the inferred key so we can push a pointer below.
 			if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
 				inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, s.args, s.cf.Config.Env, fileContext, stageFinalCacheKeys)
 				if err == nil {
@@ -493,16 +515,27 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 
 				logrus.Debugf("Build: cache key for command %v %v", command.String(), ck)
 
-				altCacheKey := inferredCacheKey
-				if altCacheKey == ck {
-					altCacheKey = ""
-				}
-
 				// Push layer to cache (in parallel) now along with new config file
 				if command.ShouldCacheOutput() && !opts.NoPushCache {
 					cacheGroup.Go(func() error {
-						return pushCache(opts, ck, altCacheKey, tarPath, command.String())
+						return pushCache(opts, ck, tarPath, command.String())
 					})
+					// mz334: also push a pointer under the inferred key so that a
+					// subsequent optimize pass can find the content key and continue
+					// the cache chain without unpacking the source stage.
+					if inferredCacheKey != "" && inferredCacheKey != ck {
+						rawKey := compositeKey.Key()
+						h, err := NewCompositeCache(rawKey).Hash()
+						if err != nil {
+							return err
+						}
+						if h != ck {
+							logrus.Panicf("Unreachable: rawCompositeKey hash %v does not match ck %v", h, ck)
+						}
+						cacheGroup.Go(func() error {
+							return pushPointer(opts, inferredCacheKey, rawKey)
+						})
+					}
 				}
 			}
 			s.image, err = saveSnapshotToImage(s.image, command.String(), tarPath, opts)

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -846,7 +846,6 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 // DoBuild executes building the Dockerfile
 func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	t := timing.Start("Total Build Time")
-	digestToCacheKey := make(map[string]string)
 	stageFinalCacheKeys := make(map[int]string)
 
 	stages, metaArgs, err := dockerfile.ParseStages(opts)
@@ -956,9 +955,12 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 
 		// Set the initial cache key to be the base image digest
 		var compositeKey *CompositeCache
-		if cacheKey, ok := digestToCacheKey[sb.baseImageDigest]; ok {
-			compositeKey = NewCompositeCache(cacheKey)
-		} else {
+		if stage.BaseImageStoredLocally {
+			if cacheKey, ok := stageFinalCacheKeys[stage.BaseImageIndex]; ok {
+				compositeKey = NewCompositeCache(cacheKey)
+			}
+		}
+		if compositeKey == nil {
 			compositeKey = NewCompositeCache(sb.baseImageDigest)
 		}
 
@@ -1002,15 +1004,8 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			return nil, err
 		}
 
-		d, err := sourceImage.Digest()
-		if err != nil {
-			return nil, err
-		}
-		logrus.Debugf("Mapping stage idx %v to digest %v", sb.index, d.String())
-
-		digestToCacheKey[d.String()] = finalCacheKey
 		stageFinalCacheKeys[stage.Index] = finalCacheKey
-		logrus.Debugf("Mapping digest %v to cachekey %v", d.String(), finalCacheKey)
+		logrus.Debugf("Mapping stage idx %v to cachekey %v", stage.Index, finalCacheKey)
 
 		if stage.Push {
 			sourceImage, err = mutate.CreatedAt(sourceImage, v1.Time{Time: time.Now()})

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -220,6 +220,9 @@ func crossStageCacheKey(command commands.DockerCommand, stageFinalCacheKeys map[
 }
 
 func populateCompositeKey(command commands.DockerCommand, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string, fileContext util.FileContext, stageFinalCacheKeys map[int]string) (CompositeCache, error) {
+	if files != nil && stageFinalCacheKeys != nil {
+		logrus.Panic("Unreachable Code: files and stageFinalCacheKeys are mutually exclusive")
+	}
 	// First replace all the environment variables or args in the command
 	replacementEnvs := args.ReplacementEnvs(env)
 	// The sort order of `replacementEnvs` is basically undefined, sort it
@@ -240,26 +243,30 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 	// Add the next command to the cache key.
 	compositeKey.AddKey(command.String())
 
-	// mz334: COPY --from shortcut — use the source stage's cache key instead of hashing files.
-	if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") {
+	if stageFinalCacheKeys != nil {
+		// mz334: COPY --from shortcut — use the source stage's cache key instead of hashing files.
 		cacheKey, ok := crossStageCacheKey(command, stageFinalCacheKeys)
 		if ok {
 			compositeKey.AddKey(cacheKey)
 			return compositeKey, nil
 		}
+		return compositeKey, fmt.Errorf("shortcut key not found")
+	} else if files != nil {
+		for _, f := range files {
+			if err := compositeKey.AddPath(f, fileContext); err != nil {
+				return compositeKey, err
+			}
+		}
+		return compositeKey, nil
 	}
 
-	for _, f := range files {
-		if err := compositeKey.AddPath(f, fileContext); err != nil {
-			return compositeKey, err
-		}
-	}
+	logrus.Panic("Unreachable Code")
 	return compositeKey, nil
 }
 
-func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, stageFinalCacheKeys map[int]string) (string, bool, error) {
+func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts *config.KanikoOptions, fileContext util.FileContext, layerCache cache.LayerCache, stageFinalCacheKeys map[int]string) (string, error) {
 	if !opts.Cache {
-		return "", false, nil
+		return "", nil
 	}
 	buildArgs := s.args.Clone()
 	// Restore build args back to their original values
@@ -279,27 +286,47 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 		}
 		files, err := command.FilesUsedFromContext(&cfg, s.args)
 		if err != nil {
-			return "", false, fmt.Errorf("failed to get files used from context: %w", err)
+			return "", fmt.Errorf("failed to get files used from context: %w", err)
 		}
 
-		compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, cfg.Env, fileContext, stageFinalCacheKeys)
+		prevCompositeKey := compositeKey.Clone()
+		compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, cfg.Env, fileContext, nil)
 		if err != nil {
-			return "", false, err
+			return "", err
 		}
 
 		logrus.Debugf("Optimize: composite key for command %v %v", command.String(), compositeKey)
 		ck, err := compositeKey.Hash()
 		if err != nil {
-			return "", false, fmt.Errorf("failed to hash composite key: %w", err)
+			return "", fmt.Errorf("failed to hash composite key: %w", err)
 		}
 
 		logrus.Debugf("Optimize: cache key for command %v %v", command.String(), ck)
 		finalCacheKey = ck
 
 		if command.ShouldCacheOutput() && !stopCache {
-			img, err := layerCache.RetrieveLayer(ck)
-			if err != nil {
-				logrus.Debugf("Failed to retrieve layer: %s", err)
+			var img v1.Image
+			lookupErr := fmt.Errorf("no cache lookup attempted")
+
+			// mz334: When FF is enabled, try the inferred key first so we can observe
+			// and log inferred-key hits (integration test observability).
+			if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
+				inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, s.args, cfg.Env, fileContext, stageFinalCacheKeys)
+				if err == nil {
+					inferredCk, err := inferredKey.Hash()
+					if err == nil && inferredCk != ck {
+						img, lookupErr = layerCache.RetrieveLayer(inferredCk)
+					}
+				}
+			}
+
+			usedInferredKey := lookupErr == nil
+			if lookupErr != nil {
+				img, lookupErr = layerCache.RetrieveLayer(ck)
+			}
+
+			if lookupErr != nil {
+				logrus.Debugf("Failed to retrieve layer: %s", lookupErr)
 				logrus.Infof("No cached layer found for cmd %s", command.String())
 				logrus.Debugf("Key missing was: %s", compositeKey.Key())
 				stopCache = true
@@ -307,11 +334,9 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 			}
 
 			if cacheCmd := command.CacheCommand(img); cacheCmd != nil {
-				// mz334: add a log s.t. it becomes integration test testable
-				if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") {
-					if _, ok := crossStageCacheKey(command, stageFinalCacheKeys); ok {
-						logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
-					}
+				// mz334: log when the inferred key produced the hit (integration test observability only).
+				if usedInferredKey {
+					logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
 				}
 				logrus.Infof("Using caching version of cmd: %s", command.String())
 				s.cmds[i] = cacheCmd
@@ -321,11 +346,11 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 		// Mutate the config for any commands that require it.
 		if command.MetadataOnly() {
 			if err := command.ExecuteCommand(&cfg, s.args); err != nil {
-				return "", false, err
+				return "", err
 			}
 		}
 	}
-	return finalCacheKey, !stopCache, nil
+	return finalCacheKey, nil
 }
 
 func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageFinalCacheKeys map[int]string) error {
@@ -389,23 +414,18 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			return fmt.Errorf("failed to get files used from context: %w", err)
 		}
 
-		var contentCacheKey string
+		var inferredCacheKey string
 		if opts.Cache {
-			prevCompositeKey := compositeKey
-			compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext, stageFinalCacheKeys)
+			prevCompositeKey := compositeKey.Clone()
+			compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext, nil)
 			if err != nil {
 				return err
 			}
-			// mz334: If the shortcut was used, pre-compute the content-addressed key so
-			// we can push under both keys below.
+			// mz334: also compute the inferred key so we can push under both keys below.
 			if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
-				_, ok := crossStageCacheKey(command, stageFinalCacheKeys)
-				if ok {
-					contentKey, err := populateCompositeKey(command, files, prevCompositeKey, s.args, s.cf.Config.Env, fileContext, nil)
-					if err != nil {
-						return err
-					}
-					contentCacheKey, err = contentKey.Hash()
+				inferredKey, err := populateCompositeKey(command, nil, prevCompositeKey, s.args, s.cf.Config.Env, fileContext, stageFinalCacheKeys)
+				if err == nil {
+					inferredCacheKey, err = inferredKey.Hash()
 					if err != nil {
 						return err
 					}
@@ -473,10 +493,15 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 
 				logrus.Debugf("Build: cache key for command %v %v", command.String(), ck)
 
+				altCacheKey := inferredCacheKey
+				if altCacheKey == ck {
+					altCacheKey = ""
+				}
+
 				// Push layer to cache (in parallel) now along with new config file
 				if command.ShouldCacheOutput() && !opts.NoPushCache {
 					cacheGroup.Go(func() error {
-						return pushCache(opts, ck, contentCacheKey, tarPath, command.String())
+						return pushCache(opts, ck, altCacheKey, tarPath, command.String())
 					})
 				}
 			}
@@ -822,9 +847,6 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	t := timing.Start("Total Build Time")
 	digestToCacheKey := make(map[string]string)
-
-	// mz334: when FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY is set, a fully-cached
-	// stage's finalCacheKey is used as a proxy for COPY --from= file hashing.
 	stageFinalCacheKeys := make(map[int]string)
 
 	stages, metaArgs, err := dockerfile.ParseStages(opts)
@@ -941,7 +963,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		}
 
 		// Apply optimizations to the instructions.
-		finalCacheKey, fullyCached, err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts), stageFinalCacheKeys)
+		finalCacheKey, err := sb.optimize(*compositeKey, sb.cf.Config, opts, fileContext, newLayerCache(opts), stageFinalCacheKeys)
 		if err != nil {
 			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
 		}
@@ -987,11 +1009,8 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		logrus.Debugf("Mapping stage idx %v to digest %v", sb.index, d.String())
 
 		digestToCacheKey[d.String()] = finalCacheKey
+		stageFinalCacheKeys[stage.Index] = finalCacheKey
 		logrus.Debugf("Mapping digest %v to cachekey %v", d.String(), finalCacheKey)
-
-		if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && fullyCached && opts.Cache && opts.CacheCopyLayers {
-			stageFinalCacheKeys[stage.Index] = finalCacheKey
-		}
 
 		if stage.Push {
 			sourceImage, err = mutate.CreatedAt(sourceImage, v1.Time{Time: time.Now()})

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -383,10 +383,27 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			return fmt.Errorf("failed to get files used from context: %w", err)
 		}
 
+		var contentCacheKey string
 		if opts.Cache {
+			prevCompositeKey := compositeKey
 			compositeKey, err = populateCompositeKey(command, files, compositeKey, s.args, s.cf.Config.Env, fileContext, stageFinalCacheKeys)
 			if err != nil {
 				return err
+			}
+			// mz334: If the shortcut was used, pre-compute the content-addressed key so
+			// we can push under both keys below.
+			if config.EnvBool("FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY") && opts.CacheCopyLayers {
+				_, ok := crossStageCacheKey(command, stageFinalCacheKeys)
+				if ok {
+					contentKey, err := populateCompositeKey(command, files, prevCompositeKey, s.args, s.cf.Config.Env, fileContext, nil)
+					if err != nil {
+						return err
+					}
+					contentCacheKey, err = contentKey.Hash()
+					if err != nil {
+						return err
+					}
+				}
 			}
 		}
 
@@ -453,7 +470,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 				// Push layer to cache (in parallel) now along with new config file
 				if command.ShouldCacheOutput() && !opts.NoPushCache {
 					cacheGroup.Go(func() error {
-						return pushCache(opts, ck, tarPath, command.String())
+						return pushCache(opts, ck, contentCacheKey, tarPath, command.String())
 					})
 				}
 			}

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -608,7 +608,7 @@ func Test_stageBuilder_optimize(t *testing.T) {
 				cacheCommand: MockCachedDockerCommand{},
 			}
 			sb.cmds = []commands.DockerCommand{command}
-			_, err = sb.optimize(ck, cf.Config, tc.opts, util.FileContext{}, lc)
+			_, _, err = sb.optimize(ck, cf.Config, tc.opts, util.FileContext{}, lc, nil)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}
@@ -867,11 +867,11 @@ func Test_stageBuilder_populateCompositeKey(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ck1, err := populateCompositeKey(dockerCommand1, []string{}, ck, tc.cmd1.args, tc.cmd1.env, fc)
+			ck1, err := populateCompositeKey(dockerCommand1, []string{}, ck, tc.cmd1.args, tc.cmd1.env, fc, nil)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}
-			ck2, err := populateCompositeKey(dockerCommand2, []string{}, ck, tc.cmd2.args, tc.cmd2.env, fc)
+			ck2, err := populateCompositeKey(dockerCommand2, []string{}, ck, tc.cmd2.args, tc.cmd2.env, fc, nil)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}
@@ -1485,11 +1485,11 @@ RUN foobar
 				getFSFromImage = tc.mockGetFSFromImage
 			}
 			compositeKey := NewCompositeCache(sb.baseImageDigest)
-			_, err := sb.optimize(*compositeKey, sb.cf.Config, tc.opts, util.FileContext{}, lc)
+			_, _, err := sb.optimize(*compositeKey, sb.cf.Config, tc.opts, util.FileContext{}, lc, nil)
 			if err != nil {
 				t.Errorf("failed to optimize instructions: %v", err)
 			}
-			err = sb.build(*compositeKey, tc.opts, util.FileContext{}, snap, tc.crossStageDeps)
+			err = sb.build(*compositeKey, tc.opts, util.FileContext{}, snap, tc.crossStageDeps, nil)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}
@@ -1654,6 +1654,7 @@ func Test_stageBuild_populateCompositeKeyForCopyCommand(t *testing.T) {
 						dockerfile.NewBuildArgs([]string{}),
 						[]string{},
 						fc,
+						nil,
 					)
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -608,7 +608,7 @@ func Test_stageBuilder_optimize(t *testing.T) {
 				cacheCommand: MockCachedDockerCommand{},
 			}
 			sb.cmds = []commands.DockerCommand{command}
-			_, _, err = sb.optimize(ck, cf.Config, tc.opts, util.FileContext{}, lc, nil)
+			_, err = sb.optimize(ck, cf.Config, tc.opts, util.FileContext{}, lc, nil)
 			if err != nil {
 				t.Errorf("Expected error to be nil but was %v", err)
 			}
@@ -1488,7 +1488,7 @@ RUN foobar
 				getFSFromImage = tc.mockGetFSFromImage
 			}
 			compositeKey := NewCompositeCache(sb.baseImageDigest)
-			_, _, err := sb.optimize(*compositeKey, sb.cf.Config, tc.opts, util.FileContext{}, lc, nil)
+			_, err := sb.optimize(*compositeKey, sb.cf.Config, tc.opts, util.FileContext{}, lc, nil)
 			if err != nil {
 				t.Errorf("failed to optimize instructions: %v", err)
 			}

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -1467,11 +1467,8 @@ RUN foobar
 			}
 			originalPushCache := pushCache
 			defer func() { pushCache = originalPushCache }()
-			pushCache = func(_ *config.KanikoOptions, cacheKey, altCacheKey, _, _ string) error {
+			pushCache = func(_ *config.KanikoOptions, cacheKey, _, _ string) error {
 				keys = append(keys, cacheKey)
-				if altCacheKey != "" {
-					keys = append(keys, altCacheKey)
-				}
 				return nil
 			}
 			sb.cmds = tc.commands

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -1467,8 +1467,11 @@ RUN foobar
 			}
 			originalPushCache := pushCache
 			defer func() { pushCache = originalPushCache }()
-			pushCache = func(_ *config.KanikoOptions, cacheKey, _, _ string) error {
+			pushCache = func(_ *config.KanikoOptions, cacheKey, altCacheKey, _, _ string) error {
 				keys = append(keys, cacheKey)
+				if altCacheKey != "" {
+					keys = append(keys, altCacheKey)
+				}
 				return nil
 			}
 			sb.cmds = tc.commands

--- a/pkg/executor/composite_cache.go
+++ b/pkg/executor/composite_cache.go
@@ -41,6 +41,11 @@ type CompositeCache struct {
 	keys []string
 }
 
+// Clone returns an independent copy of the CompositeCache with its own backing array.
+func (s CompositeCache) Clone() CompositeCache {
+	return CompositeCache{keys: append([]string(nil), s.keys...)}
+}
+
 // AddKey adds the specified key to the sequence.
 func (s *CompositeCache) AddKey(k ...string) {
 	s.keys = append(s.keys, k...)

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -356,7 +356,7 @@ func writeImageOutputs(image v1.Image, destRefs []name.Tag) error {
 
 // pushLayerToCache pushes layer (tagged with cacheKey) to opts.CacheRepo
 // if opts.CacheRepo doesn't exist, infer the cache from the given destination
-func pushLayerToCache(opts *config.KanikoOptions, cacheKey, altCacheKey string, tarPath string, createdBy string) error {
+func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath string, createdBy string) error {
 	var layerOpts []tarball.LayerOption
 	if opts.CompressedCaching {
 		layerOpts = append(layerOpts, tarball.WithCompressedCaching)
@@ -379,22 +379,11 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey, altCacheKey string, 
 		return err
 	}
 
-	dest, err := cache.Destination(opts, cacheKey)
+	cache, err := cache.Destination(opts, cacheKey)
 	if err != nil {
 		return fmt.Errorf("getting cache destination: %w", err)
 	}
-	if altCacheKey != "" && isOCILayout(dest) {
-		return fmt.Errorf("alt cache key is not supported for OCI layout destinations")
-	}
-	destinations := []string{dest}
-	if altCacheKey != "" {
-		altDest, err := cache.Destination(opts, altCacheKey)
-		if err != nil {
-			return fmt.Errorf("getting alt cache destination: %w", err)
-		}
-		destinations = append(destinations, altDest)
-	}
-	logrus.Infof("Pushing layer to cache: %v", destinations)
+	logrus.Infof("Pushing layer %s to cache now", cache)
 	empty := empty.Image
 	empty, err = mutate.CreatedAt(empty, v1.Time{Time: time.Now()})
 	if err != nil {
@@ -416,14 +405,58 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey, altCacheKey string, 
 	cacheOpts := *opts
 	cacheOpts.TarPath = ""              // tarPath doesn't make sense for Docker layers
 	cacheOpts.NoPush = opts.NoPushCache // we do not want to push cache if --no-push-cache is set.
-	cacheOpts.Destinations = destinations
+	cacheOpts.Destinations = []string{cache}
+	cacheOpts.InsecureRegistries = opts.InsecureRegistries
+	cacheOpts.SkipTLSVerifyRegistries = opts.SkipTLSVerifyRegistries
+	if isOCILayout(cache) {
+		cacheOpts.OCILayoutPath = strings.TrimPrefix(cache, "oci:")
+		cacheOpts.NoPush = true
+	}
+	return DoPush(empty, &cacheOpts)
+}
+
+const cachePointerLabel = "kaniko.cache.pointer-target"
+
+// pushCachePointer pushes a lightweight pointer entry under inferredKey that records
+// the content-addressed contentKey. On a subsequent build, resolving the pointer via
+// resolveCachePointer gives the contentKey so the cache chain can be continued correctly.
+func pushCachePointer(opts *config.KanikoOptions, inferredKey, contentKey string) error {
+	dest, err := cache.Destination(opts, inferredKey)
+	if err != nil {
+		return fmt.Errorf("getting cache destination for pointer: %w", err)
+	}
+	logrus.Infof("Pushing cache pointer %v -> %v", dest, contentKey)
+
+	cf := &v1.ConfigFile{}
+	cf.Created = v1.Time{Time: time.Now()}
+	cf.Config.Labels = map[string]string{cachePointerLabel: contentKey}
+	img, err := mutate.ConfigFile(empty.Image, cf)
+	if err != nil {
+		return fmt.Errorf("building pointer image: %w", err)
+	}
+
+	cacheOpts := *opts
+	cacheOpts.TarPath = ""
+	cacheOpts.NoPush = opts.NoPushCache
+	cacheOpts.Destinations = []string{dest}
 	cacheOpts.InsecureRegistries = opts.InsecureRegistries
 	cacheOpts.SkipTLSVerifyRegistries = opts.SkipTLSVerifyRegistries
 	if isOCILayout(dest) {
 		cacheOpts.OCILayoutPath = strings.TrimPrefix(dest, "oci:")
 		cacheOpts.NoPush = true
 	}
-	return DoPush(empty, &cacheOpts)
+	return DoPush(img, &cacheOpts)
+}
+
+// resolveCachePointer checks whether img is a pointer entry pushed by pushCachePointer
+// and returns the target content key. Returns ("", false) for regular layer images.
+func resolveCachePointer(img v1.Image) (string, bool) {
+	cf, err := img.ConfigFile()
+	if err != nil || cf.Config.Labels == nil {
+		return "", false
+	}
+	target, ok := cf.Config.Labels[cachePointerLabel]
+	return target, ok
 }
 
 // setDummyDestinations sets the dummy destinations required to generate new

--- a/pkg/executor/push.go
+++ b/pkg/executor/push.go
@@ -356,7 +356,7 @@ func writeImageOutputs(image v1.Image, destRefs []name.Tag) error {
 
 // pushLayerToCache pushes layer (tagged with cacheKey) to opts.CacheRepo
 // if opts.CacheRepo doesn't exist, infer the cache from the given destination
-func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath string, createdBy string) error {
+func pushLayerToCache(opts *config.KanikoOptions, cacheKey, altCacheKey string, tarPath string, createdBy string) error {
 	var layerOpts []tarball.LayerOption
 	if opts.CompressedCaching {
 		layerOpts = append(layerOpts, tarball.WithCompressedCaching)
@@ -379,11 +379,22 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 		return err
 	}
 
-	cache, err := cache.Destination(opts, cacheKey)
+	dest, err := cache.Destination(opts, cacheKey)
 	if err != nil {
 		return fmt.Errorf("getting cache destination: %w", err)
 	}
-	logrus.Infof("Pushing layer %s to cache now", cache)
+	if altCacheKey != "" && isOCILayout(dest) {
+		return fmt.Errorf("alt cache key is not supported for OCI layout destinations")
+	}
+	destinations := []string{dest}
+	if altCacheKey != "" {
+		altDest, err := cache.Destination(opts, altCacheKey)
+		if err != nil {
+			return fmt.Errorf("getting alt cache destination: %w", err)
+		}
+		destinations = append(destinations, altDest)
+	}
+	logrus.Infof("Pushing layer to cache: %v", destinations)
 	empty := empty.Image
 	empty, err = mutate.CreatedAt(empty, v1.Time{Time: time.Now()})
 	if err != nil {
@@ -405,11 +416,11 @@ func pushLayerToCache(opts *config.KanikoOptions, cacheKey string, tarPath strin
 	cacheOpts := *opts
 	cacheOpts.TarPath = ""              // tarPath doesn't make sense for Docker layers
 	cacheOpts.NoPush = opts.NoPushCache // we do not want to push cache if --no-push-cache is set.
-	cacheOpts.Destinations = []string{cache}
+	cacheOpts.Destinations = destinations
 	cacheOpts.InsecureRegistries = opts.InsecureRegistries
 	cacheOpts.SkipTLSVerifyRegistries = opts.SkipTLSVerifyRegistries
-	if isOCILayout(cache) {
-		cacheOpts.OCILayoutPath = strings.TrimPrefix(cache, "oci:")
+	if isOCILayout(dest) {
+		cacheOpts.OCILayoutPath = strings.TrimPrefix(dest, "oci:")
 		cacheOpts.NoPush = true
 	}
 	return DoPush(empty, &cacheOpts)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

In preparation to cache lookahead https://github.com/osscontainertools/kaniko/pull/542

**Description**
Whilst working on cache lookahead I realized that we do not get any benefits from the splitting off the optimize loop, as no matter whether we have 100% cache hitrate or not, we must unroll the filesystem for all upstream stages s.t. we know whether we have a cache hit or not. This is because the cache key for `COPY --from=<stage>` is entirely based on the file contents that are copied, without unrolling the upstream stage we can't infer the file contents, we can't infer the cache key, we can't infer whether we have a hit or not. If we have a hit, the unrolling of the filesystem was entirely in vain, as we are not going to use those files, we are going to use the cached entry anyways.

This change introduces a shortcut: when the source stage is fully cached, its finalCacheKey is a stable proxy for those file contents and can be used directly without reading any files. However, the current mechanism of hashing the file contents should be a bit more stable, as if we change files we do not care about, or change image metadata, the `finalCacheKey` might change but the file content might remain exactly the same. To not introduce a downgrade for the user we now support both caching mechanisms. This means `COPY --from=<stage>` layers now emit two cache entries, one is content addressed (current behaviour), one is cachekey addressed (new shortcut).

The behaviour is featureflagged, not because it would be breaking, but there is no benefit to emitting both cache layers until cache lookahead is implemented. There is no benefit to cache lookahead unless cache keys are inferred. So my plan is to activate them together.

