### PR TITLE
add assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,7 +1205,7 @@ Becomes default in `v1.28.0`.
 Kaniko checks internal invariants at runtime. If one is violated the build stops with a message like:
 
 ```
-Assertion violated [executor.build.fs-unpacked]: ...
+Assertion violated [executor.build.metadata-only]: ...
 ```
 
 This is always a bug in kaniko, please [open an issue](https://github.com/osscontainertools/kaniko/issues).
@@ -1213,7 +1213,7 @@ This is always a bug in kaniko, please [open an issue](https://github.com/osscon
 As a temporary workaround, pass the name in brackets to `KANIKO_IGNORE_ASSERTIONS` to skip that assertion and log a warning instead:
 
 ```sh
-KANIKO_IGNORE_ASSERTIONS=executor.build.fs-unpacked
+KANIKO_IGNORE_ASSERTIONS=executor.build.metadata-only
 ```
 
 Multiple names can be passed as a comma-separated list.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `--image-fs-extract-retry`](#flag---image-fs-extract-retry)
       - [Flag `--image-download-retry`](#flag---image-download-retry)
     - [Feature Flags](#feature-flags)
+    - [Assertion Overrides](#assertion-overrides)
       - [Flag `FF_KANIKO_COPY_AS_ROOT`](#flag-ff_kaniko_copy_as_root)
       - [Flag `FF_KANIKO_SQUASH_STAGES`](#flag-ff_kaniko_squash_stages)
       - [Flag `FF_KANIKO_IGNORE_CACHED_MANIFEST`](#flag-ff_kaniko_ignore_cached_manifest)
@@ -1198,6 +1199,24 @@ When a multi-stage build uses `COPY --from=<stage>`, kaniko normally hashes the 
 Set this flag to `true` to add additional cache entries for the shortcuts, currently they do not yet allow optimization.
 Requires `--cache-copy-layers`. Defaults to `false`.
 Becomes default in `v1.28.0`.
+
+### Assertion Overrides
+
+Kaniko checks internal invariants at runtime. If one is violated the build stops with a message like:
+
+```
+Assertion violated [executor.build.fs-unpacked]: ...
+```
+
+This is always a bug in kaniko, please [open an issue](https://github.com/osscontainertools/kaniko/issues).
+
+As a temporary workaround, pass the name in brackets to `KANIKO_IGNORE_ASSERTIONS` to skip that assertion and log a warning instead:
+
+```sh
+KANIKO_IGNORE_ASSERTIONS=executor.build.fs-unpacked
+```
+
+Multiple names can be passed as a comma-separated list.
 
 ### Debug Image
 

--- a/integration/dockerfiles/Dockerfile_test_issue_mz621
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz621
@@ -3,6 +3,6 @@
 # In single-snapshot mode TakeSnapshotFS accumulates all build changes; the
 # "MetadataOnly command snapshotted N files" assertion must be gated on
 # !opts.SingleSnapshot.
-FROM alpine
+FROM busybox
 RUN touch /x
 LABEL a=b

--- a/integration/dockerfiles/Dockerfile_test_issue_mz621
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz621
@@ -1,0 +1,8 @@
+# mz621: --single-snapshot with a metadata-only final command (LABEL) after a
+# filesystem-modifying command (RUN) must not panic.
+# In single-snapshot mode TakeSnapshotFS accumulates all build changes; the
+# "MetadataOnly command snapshotted N files" assertion must be gated on
+# !opts.SingleSnapshot.
+FROM alpine
+RUN touch /x
+LABEL a=b

--- a/integration/images.go
+++ b/integration/images.go
@@ -166,6 +166,7 @@ var executorImages = map[string]string{
 // Arguments to build Dockerfiles with when building with kaniko
 var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_add":                    {"--single-snapshot"},
+	"Dockerfile_test_issue_mz621":            {"--single-snapshot"},
 	"Dockerfile_test_run_new":                {"--use-new-run=true"},
 	"Dockerfile_test_run_redo":               {"--snapshot-mode=redo"},
 	"Dockerfile_test_scratch":                {"--single-snapshot"},

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -241,6 +241,7 @@ func addCmdFilesUsedFromContext(config *v1.Config, buildArgs *dockerfile.BuildAr
 		files = append(files, fullPath)
 	}
 
+	util.Assert(len(files) <= len(srcs), "addCmdFilesUsedFromContext: remote URLs and tar archives are filtered out, so result cannot exceed source count (srcs=%d, files=%d)", len(srcs), len(files))
 	logrus.Infof("Using files from context: %v", files)
 	return files, nil
 }

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -241,7 +241,8 @@ func addCmdFilesUsedFromContext(config *v1.Config, buildArgs *dockerfile.BuildAr
 		files = append(files, fullPath)
 	}
 
-	util.Assert(len(files) <= len(srcs), "addCmdFilesUsedFromContext: remote URLs and tar archives are filtered out, so result cannot exceed source count (srcs=%d, files=%d)", len(srcs), len(files))
+	// Remote URLs and tar archives are filtered out, so the result cannot exceed the source count.
+	util.Assert(len(files) <= len(srcs), "addCmdFilesUsedFromContext: result exceeds source count (srcs=%d, files=%d)", len(srcs), len(files))
 	logrus.Infof("Using files from context: %v", files)
 	return files, nil
 }

--- a/pkg/commands/add.go
+++ b/pkg/commands/add.go
@@ -242,7 +242,7 @@ func addCmdFilesUsedFromContext(config *v1.Config, buildArgs *dockerfile.BuildAr
 	}
 
 	// Remote URLs and tar archives are filtered out, so the result cannot exceed the source count.
-	util.Assert(len(files) <= len(srcs), "addCmdFilesUsedFromContext: result exceeds source count (srcs=%d, files=%d)", len(srcs), len(files))
+	util.Assert("add.files-count", len(files) <= len(srcs), "addCmdFilesUsedFromContext: result exceeds source count (srcs=%d, files=%d)", len(srcs), len(files))
 	logrus.Infof("Using files from context: %v", files)
 	return files, nil
 }

--- a/pkg/commands/cmd.go
+++ b/pkg/commands/cmd.go
@@ -44,7 +44,7 @@ func (c *CmdCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 		}
 
 		newCommand = append(shell, strings.Join(c.cmd.CmdLine, " "))
-		util.Assert(len(newCommand) > 0, "CMD shell form produced an empty command")
+		util.Assert("cmd.command-nonempty", len(newCommand) > 0, "CMD shell form produced an empty command")
 	} else {
 		newCommand = c.cmd.CmdLine
 	}

--- a/pkg/commands/cmd.go
+++ b/pkg/commands/cmd.go
@@ -22,6 +22,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/osscontainertools/kaniko/pkg/dockerfile"
+	"github.com/osscontainertools/kaniko/pkg/util"
 )
 
 type CmdCommand struct {
@@ -47,6 +48,7 @@ func (c *CmdCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 		newCommand = c.cmd.CmdLine
 	}
 
+	util.Assert(len(newCommand) > 0, "CMD produced an empty command")
 	config.Cmd = newCommand
 	// ArgsEscaped is only used in windows environments
 	config.ArgsEscaped = false

--- a/pkg/commands/cmd.go
+++ b/pkg/commands/cmd.go
@@ -44,11 +44,11 @@ func (c *CmdCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bui
 		}
 
 		newCommand = append(shell, strings.Join(c.cmd.CmdLine, " "))
+		util.Assert(len(newCommand) > 0, "CMD shell form produced an empty command")
 	} else {
 		newCommand = c.cmd.CmdLine
 	}
 
-	util.Assert(len(newCommand) > 0, "CMD produced an empty command")
 	config.Cmd = newCommand
 	// ArgsEscaped is only used in windows environments
 	config.ArgsEscaped = false

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -333,7 +333,7 @@ func copyCmdFilesUsedFromContext(
 		files = append(files, fullPath)
 	}
 
-	util.Assert(len(files) <= len(srcs), "copyCmdFilesUsedFromContext: result cannot exceed source count (srcs=%d, files=%d)", len(srcs), len(files))
+	util.Assert("copy.files-count", len(files) <= len(srcs), "copyCmdFilesUsedFromContext: result cannot exceed source count (srcs=%d, files=%d)", len(srcs), len(files))
 	logrus.Debugf("Using files from context: %v", files)
 
 	return files, nil

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -333,7 +333,7 @@ func copyCmdFilesUsedFromContext(
 		files = append(files, fullPath)
 	}
 
-	util.Assert(len(files) == len(srcs), "copyCmdFilesUsedFromContext: every source must map to exactly one context path (srcs=%d, files=%d)", len(srcs), len(files))
+	util.Assert(len(files) <= len(srcs), "copyCmdFilesUsedFromContext: result cannot exceed source count (srcs=%d, files=%d)", len(srcs), len(files))
 	logrus.Debugf("Using files from context: %v", files)
 
 	return files, nil

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -333,6 +333,7 @@ func copyCmdFilesUsedFromContext(
 		files = append(files, fullPath)
 	}
 
+	util.Assert(len(files) == len(srcs), "copyCmdFilesUsedFromContext: every source must map to exactly one context path (srcs=%d, files=%d)", len(srcs), len(files))
 	logrus.Debugf("Using files from context: %v", files)
 
 	return files, nil

--- a/pkg/commands/expose.go
+++ b/pkg/commands/expose.go
@@ -53,7 +53,7 @@ func (r *ExposeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 			p = p + "/tcp"
 		}
 		parts := strings.Split(p, "/")
-		util.Assert(len(parts) >= 2, "port string must contain '/' after normalization")
+		util.Assert("expose.parts-count", len(parts) >= 2, "port string must contain '/' after normalization")
 		protocol := parts[1]
 		if !validProtocol(protocol) {
 			return fmt.Errorf("invalid protocol: %s", protocol)
@@ -62,7 +62,7 @@ func (r *ExposeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 		existingPorts[p] = struct{}{}
 	}
 	config.ExposedPorts = existingPorts
-	util.Assert(len(config.ExposedPorts) >= prevPortCount, "EXPOSE must not remove ports: count went from %d to %d", prevPortCount, len(config.ExposedPorts))
+	util.Assert("expose.port-count-monotone", len(config.ExposedPorts) >= prevPortCount, "EXPOSE must not remove ports: count went from %d to %d", prevPortCount, len(config.ExposedPorts))
 	return nil
 }
 

--- a/pkg/commands/expose.go
+++ b/pkg/commands/expose.go
@@ -35,6 +35,7 @@ type ExposeCommand struct {
 func (r *ExposeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
 	logrus.Info("Cmd: EXPOSE")
 	// Grab the currently exposed ports
+	prevPortCount := len(config.ExposedPorts)
 	existingPorts := config.ExposedPorts
 	if existingPorts == nil {
 		existingPorts = make(map[string]struct{})
@@ -51,7 +52,9 @@ func (r *ExposeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 		if !strings.Contains(p, "/") {
 			p = p + "/tcp"
 		}
-		protocol := strings.Split(p, "/")[1]
+		parts := strings.Split(p, "/")
+		util.Assert(len(parts) >= 2, "port string must contain '/' after normalization")
+		protocol := parts[1]
 		if !validProtocol(protocol) {
 			return fmt.Errorf("invalid protocol: %s", protocol)
 		}
@@ -59,6 +62,7 @@ func (r *ExposeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 		existingPorts[p] = struct{}{}
 	}
 	config.ExposedPorts = existingPorts
+	util.Assert(len(config.ExposedPorts) >= prevPortCount, "EXPOSE must not remove ports: count went from %d to %d", prevPortCount, len(config.ExposedPorts))
 	return nil
 }
 

--- a/pkg/commands/label.go
+++ b/pkg/commands/label.go
@@ -34,6 +34,7 @@ func (r *LabelCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.B
 }
 
 func updateLabels(labels []instructions.KeyValuePair, config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+	prevLabelCount := len(config.Labels)
 	existingLabels := config.Labels
 	if existingLabels == nil {
 		existingLabels = make(map[string]string)
@@ -60,6 +61,7 @@ func updateLabels(labels []instructions.KeyValuePair, config *v1.Config, buildAr
 	}
 
 	config.Labels = existingLabels
+	util.Assert(len(config.Labels) >= prevLabelCount, "LABEL must not remove labels: count went from %d to %d", prevLabelCount, len(config.Labels))
 	return nil
 }
 

--- a/pkg/commands/label.go
+++ b/pkg/commands/label.go
@@ -61,7 +61,7 @@ func updateLabels(labels []instructions.KeyValuePair, config *v1.Config, buildAr
 	}
 
 	config.Labels = existingLabels
-	util.Assert(len(config.Labels) >= prevLabelCount, "LABEL must not remove labels: count went from %d to %d", prevLabelCount, len(config.Labels))
+	util.Assert("label.count-monotone", len(config.Labels) >= prevLabelCount, "LABEL must not remove labels: count went from %d to %d", prevLabelCount, len(config.Labels))
 	return nil
 }
 

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -320,6 +320,8 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 			if entry[0] != "PATH" {
 				continue
 			}
+			// Replacement envs must be in KEY=VALUE form.
+			util.Assert(len(entry) == 2, "replacement env matching \"PATH\" has no '=' separator")
 			oldPath := os.Getenv("PATH")
 			err := os.Setenv("PATH", entry[1])
 			if err != nil {
@@ -333,6 +335,7 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 		}
 	}
 
+	util.Assert(len(newCommand) > 0, "runCommandInExec: newCommand is empty")
 	logrus.Infof("Cmd: %s", newCommand[0])
 	logrus.Infof("Args: %s", newCommand[1:])
 
@@ -374,6 +377,7 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting command: %w", err)
 	}
+	util.Assert(cmd.Process != nil, "cmd.Process must be set after a successful Start()")
 
 	pgid, err := syscall.Getpgid(cmd.Process.Pid)
 	if err != nil {

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -321,7 +321,7 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 				continue
 			}
 			// Replacement envs must be in KEY=VALUE form.
-			util.Assert(len(entry) == 2, "replacement env matching \"PATH\" has no '=' separator")
+			util.Assert("run.path-separator", len(entry) == 2, "replacement env matching \"PATH\" has no '=' separator")
 			oldPath := os.Getenv("PATH")
 			err := os.Setenv("PATH", entry[1])
 			if err != nil {
@@ -335,7 +335,7 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 		}
 	}
 
-	util.Assert(len(newCommand) > 0, "runCommandInExec: newCommand is empty")
+	util.Assert("run.command-nonempty", len(newCommand) > 0, "runCommandInExec: newCommand is empty")
 	logrus.Infof("Cmd: %s", newCommand[0])
 	logrus.Infof("Args: %s", newCommand[1:])
 
@@ -377,7 +377,7 @@ func runCommandInExec(config *v1.Config, buildArgs *dockerfile.BuildArgs, cmdRun
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("starting command: %w", err)
 	}
-	util.Assert(cmd.Process != nil, "cmd.Process must be set after a successful Start()")
+	util.Assert("run.process-set", cmd.Process != nil, "cmd.Process must be set after a successful Start()")
 
 	pgid, err := syscall.Getpgid(cmd.Process.Pid)
 	if err != nil {

--- a/pkg/commands/volume.go
+++ b/pkg/commands/volume.go
@@ -62,7 +62,7 @@ func (v *VolumeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 		}
 	}
 	config.Volumes = existingVolumes
-	util.Assert(len(config.Volumes) >= prevVolumeCount, "VOLUME must not remove volumes: count went from %d to %d", prevVolumeCount, len(config.Volumes))
+	util.Assert("volume.count-monotone", len(config.Volumes) >= prevVolumeCount, "VOLUME must not remove volumes: count went from %d to %d", prevVolumeCount, len(config.Volumes))
 	return nil
 }
 

--- a/pkg/commands/volume.go
+++ b/pkg/commands/volume.go
@@ -41,6 +41,7 @@ func (v *VolumeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 	if err != nil {
 		return err
 	}
+	prevVolumeCount := len(config.Volumes)
 	existingVolumes := config.Volumes
 	if existingVolumes == nil {
 		existingVolumes = map[string]struct{}{}
@@ -61,7 +62,7 @@ func (v *VolumeCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.
 		}
 	}
 	config.Volumes = existingVolumes
-
+	util.Assert(len(config.Volumes) >= prevVolumeCount, "VOLUME must not remove volumes: count went from %d to %d", prevVolumeCount, len(config.Volumes))
 	return nil
 }
 

--- a/pkg/commands/workdir.go
+++ b/pkg/commands/workdir.go
@@ -47,7 +47,7 @@ func ToAbsPath(path string, workdir string) string {
 			result = filepath.Join("/", path)
 		}
 	}
-	util.Assert(filepath.IsAbs(result), "ToAbsPath must return an absolute path, got %q (path=%q, workdir=%q)", result, path, workdir)
+	util.Assert("workdir.abs-path", filepath.IsAbs(result), "ToAbsPath must return an absolute path, got %q (path=%q, workdir=%q)", result, path, workdir)
 	return result
 }
 

--- a/pkg/commands/workdir.go
+++ b/pkg/commands/workdir.go
@@ -37,15 +37,18 @@ type WorkdirCommand struct {
 }
 
 func ToAbsPath(path string, workdir string) string {
+	var result string
 	if filepath.IsAbs(path) {
-		return path
+		result = path
 	} else {
 		if workdir != "" {
-			return filepath.Join(workdir, path)
+			result = filepath.Join(workdir, path)
 		} else {
-			return filepath.Join("/", path)
+			result = filepath.Join("/", path)
 		}
 	}
+	util.Assert(filepath.IsAbs(result), "ToAbsPath must return an absolute path, got %q (path=%q, workdir=%q)", result, path, workdir)
+	return result
 }
 
 // For testing

--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -106,9 +106,9 @@ func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
 		result = append(result, fmt.Sprintf("%s=%s", key, *val))
 	}
 	// Args can add keys but must not remove existing env keys.
-	util.Assert(nenvs <= len(result), "ReplacementEnvs: result (%d) is smaller than de-duplicated envs (%d)", len(result), nenvs)
+	util.Assert("buildargs.replacement-envs.min-size", nenvs <= len(result), "ReplacementEnvs: result (%d) is smaller than de-duplicated envs (%d)", len(result), nenvs)
 	// Result is bounded by the union of unique env keys and arg keys.
-	util.Assert(len(result) <= nenvs+len(args), "ReplacementEnvs: result (%d) exceeds de-duplicated envs (%d) + args (%d)", len(result), nenvs, len(args))
+	util.Assert("buildargs.replacement-envs.max-size", len(result) <= nenvs+len(args), "ReplacementEnvs: result (%d) exceeds de-duplicated envs (%d) + args (%d)", len(result), nenvs, len(args))
 	return result
 }
 

--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -89,6 +89,8 @@ func (b *BuildArgs) Clone() *BuildArgs {
 func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
 	// 3344: merge args and envs,
 	merged := convertKVStringsToMap(envs)
+	// deduplicated envs
+	nenvs := len(merged)
 	args := b.GetAllAllowed()
 	for key, val := range args {
 		if config.EnvBool("FF_KANIKO_BUILDKIT_ARG_ENV_PRECEDENCE") {
@@ -103,8 +105,10 @@ func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
 	for key, val := range merged {
 		result = append(result, fmt.Sprintf("%s=%s", key, *val))
 	}
-	util.Assert(len(envs) <= len(result), "ReplacementEnvs: result length %d must be at least input envs length %d", len(result), len(envs))
-	util.Assert(len(result) <= len(envs)+len(args), "ReplacementEnvs: result length %d must be larger than input envs length %d + args lenght %d", len(result), len(envs), len(args))
+	// Args can add keys but must not remove existing env keys.
+	util.Assert(nenvs <= len(result), "ReplacementEnvs: result (%d) is smaller than de-duplicated envs (%d)", len(result), nenvs)
+	// Result is bounded by the union of unique env keys and arg keys.
+	util.Assert(len(result) <= nenvs+len(args), "ReplacementEnvs: result (%d) exceeds de-duplicated envs (%d) + args (%d)", len(result), nenvs, len(args))
 	return result
 }
 

--- a/pkg/dockerfile/buildargs.go
+++ b/pkg/dockerfile/buildargs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/osscontainertools/kaniko/pkg/config"
+	"github.com/osscontainertools/kaniko/pkg/util"
 )
 
 // builtinAllowedBuildArgs is list of built-in allowed build args
@@ -88,7 +89,8 @@ func (b *BuildArgs) Clone() *BuildArgs {
 func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
 	// 3344: merge args and envs,
 	merged := convertKVStringsToMap(envs)
-	for key, val := range b.GetAllAllowed() {
+	args := b.GetAllAllowed()
+	for key, val := range args {
 		if config.EnvBool("FF_KANIKO_BUILDKIT_ARG_ENV_PRECEDENCE") {
 			// 3344: args always override envs
 			merged[key] = &val
@@ -101,6 +103,8 @@ func (b *BuildArgs) ReplacementEnvs(envs []string) []string {
 	for key, val := range merged {
 		result = append(result, fmt.Sprintf("%s=%s", key, *val))
 	}
+	util.Assert(len(envs) <= len(result), "ReplacementEnvs: result length %d must be at least input envs length %d", len(result), len(envs))
+	util.Assert(len(result) <= len(envs)+len(args), "ReplacementEnvs: result length %d must be larger than input envs length %d + args lenght %d", len(result), len(envs), len(args))
 	return result
 }
 

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -107,9 +107,7 @@ func Parse(b []byte) ([]instructions.Stage, []instructions.ArgCommand, error) {
 		return nil, nil, err
 	}
 	lintOptionStr, _, _, ok := parser.ParseDirective("check", b)
-	if (ok && lintOptionStr == "") || (!ok && lintOptionStr != "") {
-		util.Unreachable("invariant violation ok=%t lintOptionStr=%q", ok, lintOptionStr)
-	}
+	util.Assert("dockerfile.parse-directive.consistency", ok == (lintOptionStr != ""), "ParseDirective: ok=%t lintOptionStr=%q", ok, lintOptionStr)
 	lintConfig, err := linter.ParseLintOptions(lintOptionStr)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parsing lint options: %w", err)

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -108,7 +108,7 @@ func Parse(b []byte) ([]instructions.Stage, []instructions.ArgCommand, error) {
 	}
 	lintOptionStr, _, _, ok := parser.ParseDirective("check", b)
 	if (ok && lintOptionStr == "") || (!ok && lintOptionStr != "") {
-		logrus.Panicf("Unreachable Code: invariant violation ok=%t lintOptionStr=%q", ok, lintOptionStr)
+		util.Unreachable("invariant violation ok=%t lintOptionStr=%q", ok, lintOptionStr)
 	}
 	lintConfig, err := linter.ParseLintOptions(lintOptionStr)
 	if err != nil {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -64,8 +64,8 @@ var (
 
 type snapShotter interface {
 	Init() error
-	TakeSnapshotFS() (string, error)
-	TakeSnapshot([]string, bool) (string, error)
+	TakeSnapshotFS() (string, int, error)
+	TakeSnapshot([]string, bool) (string, int, error)
 }
 
 // stageBuilder contains all fields necessary to build one stage of a Dockerfile
@@ -508,10 +508,16 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 				}
 			}
 		} else {
-			tarPath, err := takeSnapshot(files, command.ShouldDetectDeletedFiles(), opts, snapshotter)
+			tarPath, snapshotted, err := takeSnapshot(files, command.ShouldDetectDeletedFiles(), opts, snapshotter)
 			if err != nil {
 				return fmt.Errorf("failed to take snapshot: %w", err)
 			}
+			// MetadataOnly commands must not change the filesystem.
+			util.Assert(!command.MetadataOnly() || snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
+			// Caching commands (CachingRun, CachingCopy, etc.) skip this branch and go through isCacheCommand above.
+			// Every non-caching command that doesn't require an unpacked filesystem is MetadataOnly, so no
+			// filesystem changes are possible and the snapshot must be empty.
+			util.Assert(shouldUnpack || snapshotted == 0, "build: stage %d snapshotted %d file(s) for %q without any command requiring unpacked filesystem", s.index, snapshotted, command.String())
 
 			if opts.Cache {
 				logrus.Debugf("Build: composite key for command %v %v", command.String(), compositeKey)
@@ -557,20 +563,21 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 	return nil
 }
 
-func takeSnapshot(files []string, shdDelete bool, opts *config.KanikoOptions, snapshotter snapShotter) (string, error) {
+func takeSnapshot(files []string, shdDelete bool, opts *config.KanikoOptions, snapshotter snapShotter) (string, int, error) {
 	var snapshot string
+	var snapshotted int
 	var err error
 
 	t := timing.Start("Snapshotting FS")
 	if files == nil || opts.SingleSnapshot {
-		snapshot, err = snapshotter.TakeSnapshotFS()
+		snapshot, snapshotted, err = snapshotter.TakeSnapshotFS()
 	} else {
 		// Volumes are very weird. They get snapshotted in the next command.
 		files = append(files, util.Volumes()...)
-		snapshot, err = snapshotter.TakeSnapshot(files, shdDelete)
+		snapshot, snapshotted, err = snapshotter.TakeSnapshot(files, shdDelete)
 	}
 	timing.DefaultRun.Stop(t)
-	return snapshot, err
+	return snapshot, snapshotted, err
 }
 
 func shouldTakeSnapshot(isMetadataCmd bool, isLastCommand bool, opts *config.KanikoOptions) bool {
@@ -939,7 +946,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	if opts.PreserveContext {
 		if len(kanikoStages) > 1 || opts.PreCleanup || opts.Cleanup {
 			logrus.Info("Creating snapshot of build context")
-			tarball, err = snapshotter.TakeSnapshotFS()
+			tarball, _, err = snapshotter.TakeSnapshotFS()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -520,7 +520,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 				// So the only case where we don't need a filesystem is if all commands are MetadataOnly.
 				util.Assert("executor.build.metadata-only", command.MetadataOnly(), "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
 			}
-			if command.MetadataOnly() {
+			if command.MetadataOnly() && !opts.SingleSnapshot {
 				// MetadataOnly commands must not change or even need the filesystem.
 				util.Assert("executor.build.without-fs", snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
 			}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -189,6 +189,7 @@ func initConfig(img partial.WithConfigFile, opts *config.KanikoOptions) (*v1.Con
 		}
 	}
 
+	util.Assert(imageConfig.Config.Env != nil, "initConfig: Env must be non-nil on return")
 	return imageConfig, nil
 }
 
@@ -221,9 +222,8 @@ func crossStageCacheKey(command commands.DockerCommand, stageFinalCacheKeys map[
 }
 
 func populateCompositeKey(command commands.DockerCommand, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string, fileContext util.FileContext, stageFinalCacheKeys map[int]string) (CompositeCache, error) {
-	if files != nil && stageFinalCacheKeys != nil {
-		logrus.Panic("Unreachable Code: files and stageFinalCacheKeys are mutually exclusive")
-	}
+	util.Assert(files == nil || stageFinalCacheKeys == nil, "populateCompositeKey: files and stageFinalCacheKeys are mutually exclusive")
+	util.Assert(command != nil, "populateCompositeKey called with nil command")
 	// First replace all the environment variables or args in the command
 	replacementEnvs := args.ReplacementEnvs(env)
 	// The sort order of `replacementEnvs` is basically undefined, sort it
@@ -261,7 +261,7 @@ func populateCompositeKey(command commands.DockerCommand, files []string, compos
 		return compositeKey, nil
 	}
 
-	logrus.Panic("Unreachable Code")
+	util.Unreachable("populateCompositeKey: both files and stageFinalCacheKeys are nil")
 	return compositeKey, nil
 }
 
@@ -298,6 +298,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 	if err != nil {
 		return "", err
 	}
+	cmdCountBeforeOptimize := len(s.cmds)
 	// Possibly replace commands with their cached implementations.
 	// We walk through all the commands, running any commands that only operate on metadata.
 	// We throw the metadata away after, but we need it to properly track command dependencies
@@ -334,9 +335,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 					if err != nil {
 						return "", err
 					}
-					if ick != ck {
-						logrus.Panicf("Unreachable Code: pointer inferred content key %v does not match the computed content key %v", ick, ck)
-					}
+					util.Assert(ick == ck, "pointer inferred content key %v does not match the computed content key %v", ick, ck)
 					// mz334: log when the inferred key produced the hit (integration test observability only).
 					logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
 				}
@@ -376,13 +375,14 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 		}
 	}
 
-	if finalCacheKey == "" {
-		logrus.Panic("Unreachable: finalCacheKey can't be empty")
-	}
+	// Optimize only swaps commands for cached versions.
+	util.Assert(len(s.cmds) == cmdCountBeforeOptimize, "optimize: command count must not change during optimization (before=%d, after=%d)", cmdCountBeforeOptimize, len(s.cmds))
+	util.Assert(finalCacheKey != "", "optimize: finalCacheKey can't be empty")
 	return finalCacheKey, nil
 }
 
 func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageFinalCacheKeys map[int]string) error {
+	util.Assert(s.cf != nil, "stageBuilder (index %d) has nil config file", s.index)
 	// Unpack file system to root if we need to.
 	shouldUnpack := false
 	for _, cmd := range s.cmds {
@@ -536,9 +536,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 						if err != nil {
 							return err
 						}
-						if h != ck {
-							logrus.Panicf("Unreachable: rawCompositeKey hash %v does not match ck %v", h, ck)
-						}
+						util.Assert(h == ck, "rawCompositeKey hash %v does not match ck %v", h, ck)
 						cacheGroup.Go(func() error {
 							return pushPointer(opts, inferredCacheKey, rawKey)
 						})
@@ -721,6 +719,7 @@ func convertLayerMediaType(layer v1.Layer, image v1.Image, opts *config.KanikoOp
 }
 
 func saveLayerToImage(image v1.Image, layer v1.Layer, createdBy string, opts *config.KanikoOptions) (v1.Image, error) {
+	util.Assert(layer != nil, "saveLayerToImage called with nil layer")
 	layer, err := convertLayerMediaType(layer, image, opts)
 	if err != nil {
 		return nil, err
@@ -763,6 +762,7 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
 		var err error
 		if s.BaseImageStoredLocally {
 			image = images[s.BaseImageIndex]
+			util.Assert(image != nil, "stage %d references local stage %d which has not been built yet", s.Index, s.BaseImageIndex)
 		} else if s.Name == constants.NoBaseImage {
 			image = image_util.EmptyBaseImage
 		} else {
@@ -879,7 +879,7 @@ func RenderStages(stages []config.KanikoStage, opts *config.KanikoOptions, fileC
 			printf("RESTORE CONTEXT\n\n")
 		}
 	}
-	logrus.Panic("Unreachable Code: we should always have a final stage")
+	util.Unreachable("we should always have a final stage")
 	return retErr
 }
 
@@ -909,9 +909,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	}
 	logrus.Infof("Built cross stage deps: %v", crossStageDependencies)
 
-	if len(kanikoStages) == 0 {
-		logrus.Panic("no stages to build")
-	}
+	util.Assert(len(kanikoStages) > 0, "no stages to build")
 	if opts.Dryrun {
 		return nil, RenderStages(kanikoStages, opts, fileContext, crossStageDependencies)
 	}
@@ -922,6 +920,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	}
 
 	lastStage := kanikoStages[len(kanikoStages)-1]
+	util.Assert(lastStage.Final, "last stage (index %d, name %q) must be the final stage", lastStage.Index, lastStage.Name)
 	baseArgs := dockerfile.NewBuildArgs(opts.BuildArgs)
 	err = baseArgs.InitPredefinedArgs(opts.CustomPlatform, lastStage.Name)
 	if err != nil {
@@ -980,9 +979,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if stage.BaseImageIndex >= 0 {
 			args = stageArgs[stage.BaseImageIndex]
 		}
-		if args == nil {
-			logrus.Panicf("stages must be processed in order. base stage %d not yet in stageArgs", stage.BaseImageIndex)
-		}
+		util.Assert(args != nil, "stages must be processed in order: base stage %d not yet in stageArgs", stage.BaseImageIndex)
 		// args is a pointer but is cloned inside newStageBuilder, so sharing it is safe.
 		sb, err := newStageBuilder(
 			args, opts, stage,
@@ -1065,10 +1062,8 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		}
 		if stage.Final {
 			timing.DefaultRun.Stop(t)
-			if pushImage == nil {
-				// Final stage must be last, so by definition after Push stage
-				logrus.Panic("pushImage is nil")
-			}
+			// Final stage must be last, so by definition after Push stage.
+			util.Assert(pushImage != nil, "pushImage is nil")
 			return pushImage, nil
 		}
 		if stage.SaveStage {
@@ -1110,7 +1105,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		}
 	}
 
-	logrus.Panic("unreachable - we should always have a final stage")
+	util.Unreachable("we should always have a final stage")
 	return nil, nil
 }
 
@@ -1189,6 +1184,8 @@ func deduplicatePaths(paths []string) []string {
 
 	traverse(root, "")
 
+	// Deduplication can only compress.
+	util.Assert(len(deduped) <= len(paths), "deduplicatePaths: result must not exceed input size (got %d from %d)", len(deduped), len(paths))
 	return deduped
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -513,12 +513,11 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			if err != nil {
 				return fmt.Errorf("failed to take snapshot: %w", err)
 			}
+			// Caching commands go through the isCacheCommand branch above.
+			// With shouldUnpack=false, only MetadataOnly commands can reach here.
+			util.Assert(command.MetadataOnly() || shouldUnpack, "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
 			// MetadataOnly commands must not change the filesystem.
 			util.Assert(!command.MetadataOnly() || snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
-			// Caching commands (CachingRun, CachingCopy, etc.) skip this branch and go through isCacheCommand above.
-			// Every non-caching command that doesn't require an unpacked filesystem is MetadataOnly, so no
-			// filesystem changes are possible and the snapshot must be empty.
-			util.Assert(shouldUnpack || snapshotted == 0, "build: stage %d snapshotted %d file(s) for %q without any command requiring unpacked filesystem", s.index, snapshotted, command.String())
 
 			if opts.Cache {
 				logrus.Debugf("Build: composite key for command %v %v", command.String(), compositeKey)

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -189,7 +189,7 @@ func initConfig(img partial.WithConfigFile, opts *config.KanikoOptions) (*v1.Con
 		}
 	}
 
-	util.Assert(imageConfig.Config.Env != nil, "initConfig: Env must be non-nil on return")
+	util.Assert("executor.initconfig.env-nonnull", imageConfig.Config.Env != nil, "initConfig: Env must be non-nil on return")
 	return imageConfig, nil
 }
 
@@ -222,8 +222,8 @@ func crossStageCacheKey(command commands.DockerCommand, stageFinalCacheKeys map[
 }
 
 func populateCompositeKey(command commands.DockerCommand, files []string, compositeKey CompositeCache, args *dockerfile.BuildArgs, env []string, fileContext util.FileContext, stageFinalCacheKeys map[int]string) (CompositeCache, error) {
-	util.Assert(files == nil || stageFinalCacheKeys == nil, "populateCompositeKey: files and stageFinalCacheKeys are mutually exclusive")
-	util.Assert(command != nil, "populateCompositeKey called with nil command")
+	util.Assert("executor.compositekey.mutual-exclusion", files == nil || stageFinalCacheKeys == nil, "populateCompositeKey: files and stageFinalCacheKeys are mutually exclusive")
+	util.Assert("executor.compositekey.command-nonnull", command != nil, "populateCompositeKey called with nil command")
 	// First replace all the environment variables or args in the command
 	replacementEnvs := args.ReplacementEnvs(env)
 	// The sort order of `replacementEnvs` is basically undefined, sort it
@@ -335,7 +335,7 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 					if err != nil {
 						return "", err
 					}
-					util.Assert(ick == ck, "pointer inferred content key %v does not match the computed content key %v", ick, ck)
+					util.Assert("executor.compositekey.key-match", ick == ck, "pointer inferred content key %v does not match the computed content key %v", ick, ck)
 					// mz334: log when the inferred key produced the hit (integration test observability only).
 					logrus.Infof("Cache hit via inferred cross-stage key for cmd: %s", command.String())
 				}
@@ -376,13 +376,13 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 	}
 
 	// Optimize only swaps commands for cached versions.
-	util.Assert(len(s.cmds) == cmdCountBeforeOptimize, "optimize: command count must not change during optimization (before=%d, after=%d)", cmdCountBeforeOptimize, len(s.cmds))
-	util.Assert(finalCacheKey != "", "optimize: finalCacheKey can't be empty")
+	util.Assert("executor.optimize.command-count", len(s.cmds) == cmdCountBeforeOptimize, "optimize: command count must not change during optimization (before=%d, after=%d)", cmdCountBeforeOptimize, len(s.cmds))
+	util.Assert("executor.optimize.finalcachekey", finalCacheKey != "", "optimize: finalCacheKey can't be empty")
 	return finalCacheKey, nil
 }
 
 func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOptions, fileContext util.FileContext, snapshotter snapShotter, crossStageDeps bool, stageFinalCacheKeys map[int]string) error {
-	util.Assert(s.cf != nil, "stageBuilder (index %d) has nil config file", s.index)
+	util.Assert("executor.stagebuilder.config-nonnull", s.cf != nil, "stageBuilder (index %d) has nil config file", s.index)
 	// Unpack file system to root if we need to.
 	shouldUnpack := false
 	for _, cmd := range s.cmds {
@@ -415,7 +415,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		}
 
 		timing.DefaultRun.Stop(t)
-		util.Assert(len(util.Volumes()) == 0, "stageBuilder.build: getFSFromImage must reset volumes for stage %d", s.index)
+		util.Assert("executor.getfs.volumes-reset", len(util.Volumes()) == 0, "stageBuilder.build: getFSFromImage must reset volumes for stage %d", s.index)
 	} else {
 		logrus.Info("Skipping unpacking as no commands require it.")
 	}
@@ -515,9 +515,9 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			}
 			// Caching commands go through the isCacheCommand branch above.
 			// With shouldUnpack=false, only MetadataOnly commands can reach here.
-			util.Assert(command.MetadataOnly() || shouldUnpack || (s.index == 0 && opts.InitialFSUnpacked), "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
+			util.Assert("executor.build.fs-unpacked", command.MetadataOnly() || shouldUnpack || (s.index == 0 && opts.InitialFSUnpacked), "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
 			// MetadataOnly commands must not change the filesystem.
-			util.Assert(!command.MetadataOnly() || snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
+			util.Assert("executor.build.metadata-only-snapshot", !command.MetadataOnly() || snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
 
 			if opts.Cache {
 				logrus.Debugf("Build: composite key for command %v %v", command.String(), compositeKey)
@@ -542,7 +542,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 						if err != nil {
 							return err
 						}
-						util.Assert(h == ck, "rawCompositeKey hash %v does not match ck %v", h, ck)
+						util.Assert("executor.build.key-hash", h == ck, "rawCompositeKey hash %v does not match ck %v", h, ck)
 						cacheGroup.Go(func() error {
 							return pushPointer(opts, inferredCacheKey, rawKey)
 						})
@@ -726,7 +726,7 @@ func convertLayerMediaType(layer v1.Layer, image v1.Image, opts *config.KanikoOp
 }
 
 func saveLayerToImage(image v1.Image, layer v1.Layer, createdBy string, opts *config.KanikoOptions) (v1.Image, error) {
-	util.Assert(layer != nil, "saveLayerToImage called with nil layer")
+	util.Assert("executor.savelayer.layer-nonnull", layer != nil, "saveLayerToImage called with nil layer")
 	layer, err := convertLayerMediaType(layer, image, opts)
 	if err != nil {
 		return nil, err
@@ -769,7 +769,7 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
 		var err error
 		if s.BaseImageStoredLocally {
 			image = images[s.BaseImageIndex]
-			util.Assert(image != nil, "stage %d references local stage %d which has not been built yet", s.Index, s.BaseImageIndex)
+			util.Assert("executor.build.local-stage-built", image != nil, "stage %d references local stage %d which has not been built yet", s.Index, s.BaseImageIndex)
 		} else if s.Name == constants.NoBaseImage {
 			image = image_util.EmptyBaseImage
 		} else {
@@ -916,7 +916,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	}
 	logrus.Infof("Built cross stage deps: %v", crossStageDependencies)
 
-	util.Assert(len(kanikoStages) > 0, "no stages to build")
+	util.Assert("executor.build.stages-nonempty", len(kanikoStages) > 0, "no stages to build")
 	if opts.Dryrun {
 		return nil, RenderStages(kanikoStages, opts, fileContext, crossStageDependencies)
 	}
@@ -927,7 +927,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	}
 
 	lastStage := kanikoStages[len(kanikoStages)-1]
-	util.Assert(lastStage.Final, "last stage (index %d, name %q) must be the final stage", lastStage.Index, lastStage.Name)
+	util.Assert("executor.build.last-stage-final", lastStage.Final, "last stage (index %d, name %q) must be the final stage", lastStage.Index, lastStage.Name)
 	baseArgs := dockerfile.NewBuildArgs(opts.BuildArgs)
 	err = baseArgs.InitPredefinedArgs(opts.CustomPlatform, lastStage.Name)
 	if err != nil {
@@ -986,7 +986,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if stage.BaseImageIndex >= 0 {
 			args = stageArgs[stage.BaseImageIndex]
 		}
-		util.Assert(args != nil, "stages must be processed in order: base stage %d not yet in stageArgs", stage.BaseImageIndex)
+		util.Assert("executor.build.stage-order", args != nil, "stages must be processed in order: base stage %d not yet in stageArgs", stage.BaseImageIndex)
 		// args is a pointer but is cloned inside newStageBuilder, so sharing it is safe.
 		sb, err := newStageBuilder(
 			args, opts, stage,
@@ -1070,7 +1070,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		if stage.Final {
 			timing.DefaultRun.Stop(t)
 			// Final stage must be last, so by definition after Push stage.
-			util.Assert(pushImage != nil, "pushImage is nil")
+			util.Assert("executor.build.push-image-nonnull", pushImage != nil, "pushImage is nil")
 			return pushImage, nil
 		}
 		if stage.SaveStage {
@@ -1192,7 +1192,7 @@ func deduplicatePaths(paths []string) []string {
 	traverse(root, "")
 
 	// Deduplication can only compress.
-	util.Assert(len(deduped) <= len(paths), "deduplicatePaths: result must not exceed input size (got %d from %d)", len(deduped), len(paths))
+	util.Assert("executor.dedup.size", len(deduped) <= len(paths), "deduplicatePaths: result must not exceed input size (got %d from %d)", len(deduped), len(paths))
 	return deduped
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -513,11 +513,17 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			if err != nil {
 				return fmt.Errorf("failed to take snapshot: %w", err)
 			}
-			// Caching commands go through the isCacheCommand branch above.
-			// With shouldUnpack=false, only MetadataOnly commands can reach here.
-			util.Assert("executor.build.fs-unpacked", command.MetadataOnly() || shouldUnpack || (s.index == 0 && opts.InitialFSUnpacked), "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
-			// MetadataOnly commands must not change the filesystem.
-			util.Assert("executor.build.metadata-only-snapshot", !command.MetadataOnly() || snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
+
+			unpacked := shouldUnpack || (s.index == 0 && opts.InitialFSUnpacked)
+			if !unpacked {
+				// Caching commands go through the isCacheCommand branch above
+				// So the only case where we don't need a filesystem is if all commands are MetadataOnly.
+				util.Assert("executor.build.metadata-only", command.MetadataOnly(), "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
+			}
+			if command.MetadataOnly() {
+				// MetadataOnly commands must not change or even need the filesystem.
+				util.Assert("executor.build.without-fs", snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
+			}
 
 			if opts.Cache {
 				logrus.Debugf("Build: composite key for command %v %v", command.String(), compositeKey)

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -415,6 +415,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 		}
 
 		timing.DefaultRun.Stop(t)
+		util.Assert(len(util.Volumes()) == 0, "stageBuilder.build: getFSFromImage must reset volumes for stage %d", s.index)
 	} else {
 		logrus.Info("Skipping unpacking as no commands require it.")
 	}

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -515,7 +515,7 @@ func (s *stageBuilder) build(compositeKey CompositeCache, opts *config.KanikoOpt
 			}
 			// Caching commands go through the isCacheCommand branch above.
 			// With shouldUnpack=false, only MetadataOnly commands can reach here.
-			util.Assert(command.MetadataOnly() || shouldUnpack, "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
+			util.Assert(command.MetadataOnly() || shouldUnpack || (s.index == 0 && opts.InitialFSUnpacked), "build: non-MetadataOnly command %q ran without unpacked filesystem in stage %d", command.String(), s.index)
 			// MetadataOnly commands must not change the filesystem.
 			util.Assert(!command.MetadataOnly() || snapshotted == 0, "build: MetadataOnly command %q snapshotted %d file(s)", command.String(), snapshotted)
 

--- a/pkg/executor/fakes.go
+++ b/pkg/executor/fakes.go
@@ -28,6 +28,8 @@ import (
 	"github.com/osscontainertools/kaniko/pkg/dockerfile"
 )
 
+var _ commands.Cached = MockCachedDockerCommand{}
+
 type fakeSnapShotter struct {
 	file        string
 	tarPath     string
@@ -80,7 +82,7 @@ func (m MockDockerCommand) MetadataOnly() bool {
 }
 
 func (m MockDockerCommand) RequiresUnpackedFS() bool {
-	return false
+	return true
 }
 
 func (m MockDockerCommand) ShouldCacheOutput() bool {
@@ -142,6 +144,10 @@ func (m MockCachedDockerCommand) ShouldCacheOutput() bool {
 
 func (m MockCachedDockerCommand) IsArgsEnvsRequiredInCache() bool {
 	return m.argToCompositeCache
+}
+
+func (m MockCachedDockerCommand) Layer() v1.Layer {
+	return nil
 }
 
 type fakeLayerCache struct {

--- a/pkg/executor/fakes.go
+++ b/pkg/executor/fakes.go
@@ -39,12 +39,12 @@ func (f *fakeSnapShotter) Init() error {
 	return nil
 }
 
-func (f *fakeSnapShotter) TakeSnapshotFS() (string, error) {
-	return f.tarPath, nil
+func (f *fakeSnapShotter) TakeSnapshotFS() (string, int, error) {
+	return f.tarPath, 0, nil
 }
 
-func (f *fakeSnapShotter) TakeSnapshot(_ []string, _ bool) (string, error) {
-	return f.tarPath, nil
+func (f *fakeSnapShotter) TakeSnapshot(_ []string, _ bool) (string, int, error) {
+	return f.tarPath, 0, nil
 }
 
 type MockDockerCommand struct {

--- a/pkg/snapshot/layered_map.go
+++ b/pkg/snapshot/layered_map.go
@@ -56,7 +56,6 @@ func (l *LayeredMap) Snapshot() {
 	l.adds = append(l.adds, map[string]string{})
 	l.deletes = append(l.deletes, map[string]struct{}{})
 	l.layerHashCache = map[string]string{} // Erase the hash cache for this new layer.
-	util.Assert(len(l.adds) == len(l.deletes), "Snapshot: adds and deletes layers must remain in sync after append (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
 }
 
 // Key returns a hash for added and delted files.
@@ -64,6 +63,7 @@ func (l *LayeredMap) Key() (string, error) {
 	var adds map[string]string
 	var deletes map[string]struct{}
 
+	util.Assert(len(l.adds) == len(l.deletes), "LayeredMap adds/deletes slices are out of sync (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
 	if len(l.adds) != 0 {
 		adds = l.adds[len(l.adds)-1]
 		deletes = l.deletes[len(l.deletes)-1]
@@ -96,7 +96,6 @@ func (l *LayeredMap) getCurrentImage() map[string]string {
 	maps.Copy(current, l.currentImage)
 
 	// Add the last layer on top.
-	// Snapshot() must append to both atomically.
 	util.Assert(len(l.adds) == len(l.deletes), "LayeredMap adds/deletes slices are out of sync (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
 	addedFiles := l.adds[len(l.adds)-1]
 	deletedFiles := l.deletes[len(l.deletes)-1]

--- a/pkg/snapshot/layered_map.go
+++ b/pkg/snapshot/layered_map.go
@@ -63,7 +63,7 @@ func (l *LayeredMap) Key() (string, error) {
 	var adds map[string]string
 	var deletes map[string]struct{}
 
-	util.Assert(len(l.adds) == len(l.deletes), "LayeredMap adds/deletes slices are out of sync (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
+	util.Assert("layeredmap.slices-sync", len(l.adds) == len(l.deletes), "LayeredMap adds/deletes slices are out of sync (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
 	if len(l.adds) != 0 {
 		adds = l.adds[len(l.adds)-1]
 		deletes = l.deletes[len(l.deletes)-1]
@@ -96,7 +96,7 @@ func (l *LayeredMap) getCurrentImage() map[string]string {
 	maps.Copy(current, l.currentImage)
 
 	// Add the last layer on top.
-	util.Assert(len(l.adds) == len(l.deletes), "LayeredMap adds/deletes slices are out of sync (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
+	util.Assert("layeredmap.slices-sync", len(l.adds) == len(l.deletes), "LayeredMap adds/deletes slices are out of sync (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
 	addedFiles := l.adds[len(l.adds)-1]
 	deletedFiles := l.deletes[len(l.deletes)-1]
 
@@ -141,7 +141,7 @@ func (l *LayeredMap) GetCurrentPaths() map[string]struct{} {
 // AddDelete will delete the specific files in the current layer.
 func (l *LayeredMap) AddDelete(s string) error {
 	// A layer must exist before files can be deleted.
-	util.Assert(len(l.deletes) > 0, "LayeredMap.AddDelete called before Snapshot()")
+	util.Assert("layeredmap.delete-before-snapshot", len(l.deletes) > 0, "LayeredMap.AddDelete called before Snapshot()")
 	l.isCurrentImageValid = false
 
 	l.deletes[len(l.deletes)-1][s] = struct{}{}
@@ -151,7 +151,7 @@ func (l *LayeredMap) AddDelete(s string) error {
 // Add will add the specified file s to the current layer.
 func (l *LayeredMap) Add(s string) error {
 	// A layer must exist before files can be added.
-	util.Assert(len(l.adds) > 0, "LayeredMap.Add called before Snapshot()")
+	util.Assert("layeredmap.add-before-snapshot", len(l.adds) > 0, "LayeredMap.Add called before Snapshot()")
 	l.isCurrentImageValid = false
 
 	// Use hash function and add to layers

--- a/pkg/snapshot/layered_map.go
+++ b/pkg/snapshot/layered_map.go
@@ -56,6 +56,7 @@ func (l *LayeredMap) Snapshot() {
 	l.adds = append(l.adds, map[string]string{})
 	l.deletes = append(l.deletes, map[string]struct{}{})
 	l.layerHashCache = map[string]string{} // Erase the hash cache for this new layer.
+	util.Assert(len(l.adds) == len(l.deletes), "Snapshot: adds and deletes layers must remain in sync after append (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
 }
 
 // Key returns a hash for added and delted files.
@@ -95,6 +96,8 @@ func (l *LayeredMap) getCurrentImage() map[string]string {
 	maps.Copy(current, l.currentImage)
 
 	// Add the last layer on top.
+	// Snapshot() must append to both atomically.
+	util.Assert(len(l.adds) == len(l.deletes), "LayeredMap adds/deletes slices are out of sync (adds=%d, deletes=%d)", len(l.adds), len(l.deletes))
 	addedFiles := l.adds[len(l.adds)-1]
 	deletedFiles := l.deletes[len(l.deletes)-1]
 
@@ -138,6 +141,8 @@ func (l *LayeredMap) GetCurrentPaths() map[string]struct{} {
 
 // AddDelete will delete the specific files in the current layer.
 func (l *LayeredMap) AddDelete(s string) error {
+	// A layer must exist before files can be deleted.
+	util.Assert(len(l.deletes) > 0, "LayeredMap.AddDelete called before Snapshot()")
 	l.isCurrentImageValid = false
 
 	l.deletes[len(l.deletes)-1][s] = struct{}{}
@@ -146,6 +151,8 @@ func (l *LayeredMap) AddDelete(s string) error {
 
 // Add will add the specified file s to the current layer.
 func (l *LayeredMap) Add(s string) error {
+	// A layer must exist before files can be added.
+	util.Assert(len(l.adds) > 0, "LayeredMap.Add called before Snapshot()")
 	l.isCurrentImageValid = false
 
 	// Use hash function and add to layers

--- a/pkg/snapshot/layered_map_test.go
+++ b/pkg/snapshot/layered_map_test.go
@@ -62,8 +62,8 @@ func Test_CacheKey(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			lm1 := LayeredMap{adds: []map[string]string{test.map1}, deletes: []map[string]struct{}{nil, nil}}
-			lm2 := LayeredMap{adds: []map[string]string{test.map2}, deletes: []map[string]struct{}{nil, nil}}
+			lm1 := LayeredMap{adds: []map[string]string{test.map1}, deletes: []map[string]struct{}{nil}}
+			lm2 := LayeredMap{adds: []map[string]string{test.map2}, deletes: []map[string]struct{}{nil}}
 			k1, err := lm1.Key()
 			if err != nil {
 				t.Fatalf("error getting key for map 1: %v", err)

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -50,6 +50,8 @@ func NewSnapshotter(l *LayeredMap, d string) *Snapshotter {
 
 // Init initializes a new snapshotter
 func (s *Snapshotter) Init() error {
+	util.Assert(s.l != nil, "Snapshotter.Init: layered map must be set")
+	util.Assert(s.directory != "", "Snapshotter.Init: directory must be non-empty")
 	logrus.Info("Initializing snapshotter ...")
 	_, _, err := s.scanFullFilesystem()
 	return err
@@ -63,6 +65,8 @@ func (s *Snapshotter) Key() (string, error) {
 // TakeSnapshot takes a snapshot of the specified files, avoiding directories in the ignorelist, and creates
 // a tarball of the changed files. Return contents of the tarball, and whether or not any files were changed
 func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string, error) {
+	util.Assert(s.l != nil, "Snapshotter.TakeSnapshot: layered map must be set")
+	util.Assert(s.directory != "", "Snapshotter.TakeSnapshot: directory must be non-empty")
 	err := os.MkdirAll(config.KanikoLayersDir, 0o755)
 	if err != nil {
 		return "", err
@@ -125,6 +129,8 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 // TakeSnapshotFS takes a snapshot of the filesystem, avoiding directories in the ignorelist, and creates
 // a tarball of the changed files.
 func (s *Snapshotter) TakeSnapshotFS() (string, error) {
+	util.Assert(s.l != nil, "Snapshotter.TakeSnapshotFS: layered map must be set")
+	util.Assert(s.directory != "", "Snapshotter.TakeSnapshotFS: directory must be non-empty")
 	err := os.MkdirAll(config.KanikoLayersDir, 0o755)
 	if err != nil {
 		return "", err
@@ -206,6 +212,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 		}
 		filesToAdd = append(filesToAdd, path)
 	}
+	util.Assert(len(filesToAdd) <= len(resolvedFiles), "scanFullFilesystem: ignore-list filtering can only reduce the file set (resolved=%d, toAdd=%d)", len(resolvedFiles), len(filesToAdd))
 
 	logrus.Debugf("Adding to layer: %v", filesToAdd)
 	logrus.Debugf("Deleting in layer: %v", deletedPaths)
@@ -242,6 +249,8 @@ func removeObsoleteWhiteouts(deletedFiles map[string]struct{}) (filesToWhiteout 
 		}
 	}
 
+	// Whiteouts are a subset of deleted files filtered by parent presence.
+	util.Assert(len(filesToWhiteout) <= len(deletedFiles), "removeObsoleteWhiteouts: result (%d) exceeds input (%d)", len(filesToWhiteout), len(deletedFiles))
 	return filesToWhiteout
 }
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -63,17 +63,17 @@ func (s *Snapshotter) Key() (string, error) {
 }
 
 // TakeSnapshot takes a snapshot of the specified files, avoiding directories in the ignorelist, and creates
-// a tarball of the changed files. Return contents of the tarball, and whether or not any files were changed
-func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string, error) {
+// a tarball of the changed files. Returns the tarball path and the number of files snapshotted.
+func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string, int, error) {
 	util.Assert(s.l != nil, "Snapshotter.TakeSnapshot: layered map must be set")
 	util.Assert(s.directory != "", "Snapshotter.TakeSnapshot: directory must be non-empty")
 	err := os.MkdirAll(config.KanikoLayersDir, 0o755)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	f, err := os.CreateTemp(config.KanikoLayersDir, "")
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	defer f.Close()
 
@@ -81,7 +81,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 
 	filesToAdd, err := filesystem.ResolvePaths(files, s.ignorelist)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	logrus.Info("Taking snapshot of files...")
@@ -92,7 +92,7 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 	// Add files to current layer.
 	for _, file := range filesToAdd {
 		if err := s.l.Add(file); err != nil {
-			return "", fmt.Errorf("unable to add file %s to layered map: %w", file, err)
+			return "", 0, fmt.Errorf("unable to add file %s to layered map: %w", file, err)
 		}
 	}
 
@@ -103,14 +103,14 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 			return true, nil
 		})
 		if err != nil {
-			return "", err
+			return "", 0, err
 		}
 
 		logrus.Debugf("Deleting in layer: %v", deletedFiles)
 		// Whiteout files in current layer.
 		for file := range deletedFiles {
 			if err := s.l.AddDelete(file); err != nil {
-				return "", fmt.Errorf("unable to whiteout file %s in layered map: %w", file, err)
+				return "", 0, fmt.Errorf("unable to whiteout file %s in layered map: %w", file, err)
 			}
 		}
 
@@ -121,24 +121,24 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 	t := util.NewTar(f)
 	defer t.Close()
 	if err := writeToTar(t, filesToAdd, filesToWhiteout); err != nil {
-		return "", err
+		return "", 0, err
 	}
-	return f.Name(), nil
+	return f.Name(), len(filesToAdd) + len(filesToWhiteout), nil
 }
 
 // TakeSnapshotFS takes a snapshot of the filesystem, avoiding directories in the ignorelist, and creates
-// a tarball of the changed files.
-func (s *Snapshotter) TakeSnapshotFS() (string, error) {
+// a tarball of the changed files. Returns the tarball path and the number of files snapshotted.
+func (s *Snapshotter) TakeSnapshotFS() (string, int, error) {
 	util.Assert(s.l != nil, "Snapshotter.TakeSnapshotFS: layered map must be set")
 	util.Assert(s.directory != "", "Snapshotter.TakeSnapshotFS: directory must be non-empty")
 	err := os.MkdirAll(config.KanikoLayersDir, 0o755)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	f, err := os.CreateTemp(s.getSnashotPathPrefix(), "")
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	defer f.Close()
 	t := util.NewTar(f)
@@ -146,13 +146,13 @@ func (s *Snapshotter) TakeSnapshotFS() (string, error) {
 
 	filesToAdd, filesToWhiteOut, err := s.scanFullFilesystem()
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	if err := writeToTar(t, filesToAdd, filesToWhiteOut); err != nil {
-		return "", err
+		return "", 0, err
 	}
-	return f.Name(), nil
+	return f.Name(), len(filesToAdd) + len(filesToWhiteOut), nil
 }
 
 func (s *Snapshotter) getSnashotPathPrefix() string {

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -50,8 +50,8 @@ func NewSnapshotter(l *LayeredMap, d string) *Snapshotter {
 
 // Init initializes a new snapshotter
 func (s *Snapshotter) Init() error {
-	util.Assert(s.l != nil, "Snapshotter.Init: layered map must be set")
-	util.Assert(s.directory != "", "Snapshotter.Init: directory must be non-empty")
+	util.Assert("snapshot.init.layeredmap-set", s.l != nil, "Snapshotter.Init: layered map must be set")
+	util.Assert("snapshot.init.directory-set", s.directory != "", "Snapshotter.Init: directory must be non-empty")
 	logrus.Info("Initializing snapshotter ...")
 	_, _, err := s.scanFullFilesystem()
 	return err
@@ -65,8 +65,8 @@ func (s *Snapshotter) Key() (string, error) {
 // TakeSnapshot takes a snapshot of the specified files, avoiding directories in the ignorelist, and creates
 // a tarball of the changed files. Returns the tarball path and the number of files snapshotted.
 func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string, int, error) {
-	util.Assert(s.l != nil, "Snapshotter.TakeSnapshot: layered map must be set")
-	util.Assert(s.directory != "", "Snapshotter.TakeSnapshot: directory must be non-empty")
+	util.Assert("snapshot.takesnapshot.layeredmap-set", s.l != nil, "Snapshotter.TakeSnapshot: layered map must be set")
+	util.Assert("snapshot.takesnapshot.directory-set", s.directory != "", "Snapshotter.TakeSnapshot: directory must be non-empty")
 	err := os.MkdirAll(config.KanikoLayersDir, 0o755)
 	if err != nil {
 		return "", 0, err
@@ -129,8 +129,8 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool) (string,
 // TakeSnapshotFS takes a snapshot of the filesystem, avoiding directories in the ignorelist, and creates
 // a tarball of the changed files. Returns the tarball path and the number of files snapshotted.
 func (s *Snapshotter) TakeSnapshotFS() (string, int, error) {
-	util.Assert(s.l != nil, "Snapshotter.TakeSnapshotFS: layered map must be set")
-	util.Assert(s.directory != "", "Snapshotter.TakeSnapshotFS: directory must be non-empty")
+	util.Assert("snapshot.takesnapshotfs.layeredmap-set", s.l != nil, "Snapshotter.TakeSnapshotFS: layered map must be set")
+	util.Assert("snapshot.takesnapshotfs.directory-set", s.directory != "", "Snapshotter.TakeSnapshotFS: directory must be non-empty")
 	err := os.MkdirAll(config.KanikoLayersDir, 0o755)
 	if err != nil {
 		return "", 0, err
@@ -213,7 +213,7 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 		filesToAdd = append(filesToAdd, path)
 	}
 	// Ignore-list filtering can only reduce the file set.
-	util.Assert(len(filesToAdd) <= len(resolvedFiles), "scanFullFilesystem: filesToAdd (%d) exceeds resolvedFiles (%d)", len(resolvedFiles), len(filesToAdd))
+	util.Assert("snapshot.scan.files-count", len(filesToAdd) <= len(resolvedFiles), "scanFullFilesystem: filesToAdd (%d) exceeds resolvedFiles (%d)", len(resolvedFiles), len(filesToAdd))
 
 	logrus.Debugf("Adding to layer: %v", filesToAdd)
 	logrus.Debugf("Deleting in layer: %v", deletedPaths)
@@ -251,7 +251,7 @@ func removeObsoleteWhiteouts(deletedFiles map[string]struct{}) (filesToWhiteout 
 	}
 
 	// Whiteouts are a subset of deleted files filtered by parent presence.
-	util.Assert(len(filesToWhiteout) <= len(deletedFiles), "removeObsoleteWhiteouts: result (%d) exceeds input (%d)", len(filesToWhiteout), len(deletedFiles))
+	util.Assert("snapshot.whiteouts.count", len(filesToWhiteout) <= len(deletedFiles), "removeObsoleteWhiteouts: result (%d) exceeds input (%d)", len(filesToWhiteout), len(deletedFiles))
 	return filesToWhiteout
 }
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -212,7 +212,8 @@ func (s *Snapshotter) scanFullFilesystem() ([]string, []string, error) {
 		}
 		filesToAdd = append(filesToAdd, path)
 	}
-	util.Assert(len(filesToAdd) <= len(resolvedFiles), "scanFullFilesystem: ignore-list filtering can only reduce the file set (resolved=%d, toAdd=%d)", len(resolvedFiles), len(filesToAdd))
+	// Ignore-list filtering can only reduce the file set.
+	util.Assert(len(filesToAdd) <= len(resolvedFiles), "scanFullFilesystem: filesToAdd (%d) exceeds resolvedFiles (%d)", len(resolvedFiles), len(filesToAdd))
 
 	logrus.Debugf("Adding to layer: %v", filesToAdd)
 	logrus.Debugf("Deleting in layer: %v", deletedPaths)

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -48,7 +48,7 @@ func TestSnapshotFSFileChange(t *testing.T) {
 		t.Fatalf("Error setting up fs: %s", err)
 	}
 	// Take another snapshot
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, _, err := snapshotter.TakeSnapshotFS()
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -112,7 +112,7 @@ func TestSnapshotFSIsReproducible(t *testing.T) {
 		t.Fatalf("Error setting up fs: %s", err)
 	}
 	// Take another snapshot
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, _, err := snapshotter.TakeSnapshotFS()
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -141,7 +141,7 @@ func TestSnapshotFSChangePermissions(t *testing.T) {
 		t.Fatalf("Error changing permissions on %s: %v", batPath, err)
 	}
 	// Take another snapshot
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, _, err := snapshotter.TakeSnapshotFS()
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -206,7 +206,7 @@ func TestSnapshotFSReplaceDirWithLink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, _, err := snapshotter.TakeSnapshotFS()
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -252,7 +252,7 @@ func TestSnapshotFiles(t *testing.T) {
 	filesToSnapshot := []string{
 		filepath.Join(testDir, "foo"),
 	}
-	tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, false)
+	tarPath, _, err := snapshotter.TakeSnapshot(filesToSnapshot, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +287,7 @@ func TestEmptySnapshotFS(t *testing.T) {
 	defer cleanup()
 
 	// Take snapshot with no changes
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, _, err := snapshotter.TakeSnapshotFS()
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -389,7 +389,7 @@ func TestSnapshotPreservesFileOrder(t *testing.T) {
 		}
 
 		// Take a snapshot
-		tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, false)
+		tarPath, _, err := snapshotter.TakeSnapshot(filesToSnapshot, false)
 		if err != nil {
 			t.Fatalf("Error taking snapshot of fs: %s", err)
 		}
@@ -420,7 +420,7 @@ func TestSnapshotIncludesParentDirBeforeWhiteoutFile(t *testing.T) {
 
 	// Take a snapshot
 	filesToSnapshot := []string{filepath.Join(testDir, "kaniko/file", "bar/bat")}
-	_, err = snapshotter.TakeSnapshot(filesToSnapshot, false)
+	_, _, err = snapshotter.TakeSnapshot(filesToSnapshot, false)
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -444,7 +444,7 @@ func TestSnapshotIncludesParentDirBeforeWhiteoutFile(t *testing.T) {
 	}
 
 	// Take a snapshot again
-	tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, true)
+	tarPath, _, err := snapshotter.TakeSnapshot(filesToSnapshot, true)
 	if err != nil {
 		t.Fatalf("Error taking snapshot of fs: %s", err)
 	}
@@ -510,7 +510,7 @@ func TestSnapshotPreservesWhiteoutOrder(t *testing.T) {
 		}
 
 		// Take a snapshot
-		_, err = snapshotter.TakeSnapshot(filesToSnapshot, false)
+		_, _, err = snapshotter.TakeSnapshot(filesToSnapshot, false)
 		if err != nil {
 			t.Fatalf("Error taking snapshot of fs: %s", err)
 		}
@@ -524,7 +524,7 @@ func TestSnapshotPreservesWhiteoutOrder(t *testing.T) {
 		}
 
 		// Take a snapshot again
-		tarPath, err := snapshotter.TakeSnapshot(filesToSnapshot, true)
+		tarPath, _, err := snapshotter.TakeSnapshot(filesToSnapshot, true)
 		if err != nil {
 			t.Fatalf("Error taking snapshot of fs: %s", err)
 		}
@@ -554,7 +554,7 @@ func TestSnapshotOmitsUnameGname(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tarPath, err := snapshotter.TakeSnapshotFS()
+	tarPath, _, err := snapshotter.TakeSnapshotFS()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/assert.go
+++ b/pkg/util/assert.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 OSS Container Tools
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "github.com/sirupsen/logrus"
+
+// Assert panics with an "Assertion violated:" prefix when cond is false.
+// Use it to document and enforce invariants that must always hold.
+func Assert(cond bool, format string, args ...any) {
+	if !cond {
+		logrus.Panicf("Assertion violated: "+format, args...)
+	}
+}
+
+// Unreachable panics with an "Unreachable Code:" prefix.
+// Use it to mark code paths that must never execute.
+func Unreachable(format string, args ...any) {
+	logrus.Panicf("Unreachable Code: "+format, args...)
+}

--- a/pkg/util/assert.go
+++ b/pkg/util/assert.go
@@ -16,13 +16,39 @@ limitations under the License.
 
 package util
 
-import "github.com/sirupsen/logrus"
+import (
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+var disabledAssertions map[string]struct{}
+
+func init() {
+	val := os.Getenv("KANIKO_IGNORE_ASSERTIONS")
+	if val == "" {
+		return
+	}
+	disabledAssertions = make(map[string]struct{})
+	for _, name := range strings.Split(val, ",") {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			disabledAssertions[name] = struct{}{}
+		}
+	}
+}
 
 // Assert panics with an "Assertion violated:" prefix when cond is false.
+// name identifies this assertion; set KANIKO_IGNORE_ASSERTIONS=name to skip it.
 // Use it to document and enforce invariants that must always hold.
-func Assert(cond bool, format string, args ...any) {
+func Assert(name string, cond bool, format string, args ...any) {
 	if !cond {
-		logrus.Panicf("Assertion violated: "+format, args...)
+		if _, disabled := disabledAssertions[name]; disabled {
+			logrus.Warnf("Assertion disabled ["+name+"]: "+format, args...)
+			return
+		}
+		logrus.Panicf("Assertion violated ["+name+"]: "+format, args...)
 	}
 }
 

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -55,7 +55,7 @@ func ResolveEnvironmentReplacementList(values, envs []string, isFilepath bool) (
 		}
 		resolvedValues = append(resolvedValues, resolved)
 	}
-	Assert(len(resolvedValues) == len(values), "ResolveEnvironmentReplacementList: output length %d must equal input length %d; each value must resolve to exactly one result", len(resolvedValues), len(values))
+	Assert("util.resolve-list.length", len(resolvedValues) == len(values), "ResolveEnvironmentReplacementList: output length %d must equal input length %d; each value must resolve to exactly one result", len(resolvedValues), len(values))
 	return resolvedValues, nil
 }
 
@@ -96,7 +96,7 @@ func ResolveEnvAndWildcards(sd instructions.SourcesAndDest, fileContext FileCont
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to resolve environment for dest path: %w", err)
 	}
-	Assert(len(dests) == 1, "ResolveEnvironmentReplacementList returned %d results for a single dest path input", len(dests))
+	Assert("util.resolve-dest.single", len(dests) == 1, "ResolveEnvironmentReplacementList returned %d results for a single dest path input", len(dests))
 	dest := dests[0]
 	sd.DestPath = dest
 	// Resolve wildcards and get a list of resolved sources

--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -55,6 +55,7 @@ func ResolveEnvironmentReplacementList(values, envs []string, isFilepath bool) (
 		}
 		resolvedValues = append(resolvedValues, resolved)
 	}
+	Assert(len(resolvedValues) == len(values), "ResolveEnvironmentReplacementList: output length %d must equal input length %d; each value must resolve to exactly one result", len(resolvedValues), len(values))
 	return resolvedValues, nil
 }
 
@@ -95,6 +96,7 @@ func ResolveEnvAndWildcards(sd instructions.SourcesAndDest, fileContext FileCont
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to resolve environment for dest path: %w", err)
 	}
+	Assert(len(dests) == 1, "ResolveEnvironmentReplacementList returned %d results for a single dest path input", len(dests))
 	dest := dests[0]
 	sd.DestPath = dest
 	// Resolve wildcards and get a list of resolved sources

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -104,7 +104,6 @@ func (t *Tar) AddFileToTar(p string) error {
 
 	Assert("tar.root-path-excluded", p != config.RootDir, "snapshot must not include root path '/'")
 
-
 	// Docker uses no leading / in the tarball
 	hdr.Name = strings.TrimPrefix(p, config.RootDir)
 	hdr.Name = strings.TrimLeft(hdr.Name, "/")

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -102,9 +102,8 @@ func (t *Tar) AddFileToTar(p string) error {
 		return err
 	}
 
-	if p == config.RootDir {
-		Unreachable("We should no longer snapshot '/' as it will be ignored by docker anyways")
-	}
+	Assert("tar.root-path-excluded", p != config.RootDir, "snapshot must not include root path '/'")
+
 
 	// Docker uses no leading / in the tarball
 	hdr.Name = strings.TrimPrefix(p, config.RootDir)

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -103,7 +103,7 @@ func (t *Tar) AddFileToTar(p string) error {
 	}
 
 	if p == config.RootDir {
-		logrus.Panic("Unreachable Code: We should no longer snapshot '/' as it will be ignored by docker anyways")
+		Unreachable("We should no longer snapshot '/' as it will be ignored by docker anyways")
 	}
 
 	// Docker uses no leading / in the tarball


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**
 
I let AI scan through the code and add assertions on invariants it can find, that's all.
# Add assertions to enforce build invariants

Introduces `util.Assert` and `util.Unreachable` in `pkg/util/assert.go` and uses them throughout the codebase to replace ad-hoc `logrus.Panic` calls and add new checks that were previously unenforced.

`TakeSnapshot` / `TakeSnapshotFS` now also return a file count so callers can reason about whether a snapshot was non-empty.

## Assertion categories

- **Nil checks** — config file, layer, base image, build args — at entry points where a nil would cause a confusing deref downstream.
- **Non-empty snapshot for MetadataOnly commands** — a `MetadataOnly` command must not write any files; the snapshot count makes this verifiable.
- **Unpacked filesystem for non-MetadataOnly commands** — with `shouldUnpack=false` and no pre-unpacked FS, only `MetadataOnly` commands are valid in the non-cache snapshot path.
- **Volume slice reset after unpack** — `GetFSFromImage` must reset the global `volumes` slice; the assertion immediately after the call documents and verifies this contract.
- **Command count stable across `optimize`** — `optimize` may swap commands for cached versions but must not add or remove any.
- **Deduplication can only compress** — `deduplicatePaths` result must not exceed input length.
- **Stage ordering** — stages must be processed in dependency order; `stageArgs` must be populated before a dependent stage runs.
- **Final stage invariants** — `kanikoStages` must be non-empty, the last element must be `Final`, and `pushImage` must be set before the final stage returns.

## Test fixes

`MockDockerCommand.RequiresUnpackedFS()` changed to `true` and `MockCachedDockerCommand` made to implement `commands.Cached` to align the fakes with the production invariants the new assertions enforce.