### PR TITLE
mz622: ARG values leak across sibling stages in multi-stage builds

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz622
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz622
@@ -4,14 +4,24 @@ FROM busybox AS base1
 ARG ARG1=blubb
 RUN echo "$ARG1 $ARG2" > out1
 
-FROM busybox AS base2
-ARG ARG2=bla
 # base2 never declares ARG1. out2 should contain " bla"
 # but kaniko produces "blubb bla", indicating the previous ARG leaked.
+FROM busybox AS base2
+ARG ARG2=bla
 RUN echo "$ARG1 $ARG2" > out2
+
+# base3 defines a new default value for ARG1,
+# This shouldn't interfere with what base1 defined.
+FROM busybox AS base3
+ARG ARG1=bli
+RUN echo "$ARG1 $ARG2" > out3
+FROM base1 AS base4
+RUN echo "$ARG1 $ARG2" > out4
 
 FROM busybox
 COPY --from=base1 out1 out1
 COPY --from=base2 out2 out2
-RUN echo "$ARG1 $ARG2" > out3
-RUN cat out1 out2 out3
+COPY --from=base3 out3 out3
+COPY --from=base4 out4 out4
+RUN echo "$ARG1 $ARG2" > out5
+RUN cat out1 out2 out3 out4 out5

--- a/integration/dockerfiles/Dockerfile_test_issue_mz622
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz622
@@ -1,0 +1,17 @@
+# mz622: present in kaniko v1.27.2.
+# ARG values leak across sibling stages.
+FROM busybox AS base1
+ARG ARG1=blubb
+RUN echo "$ARG1 $ARG2" > out1
+
+FROM busybox AS base2
+ARG ARG2=bla
+# base2 never declares ARG1. out2 should contain " bla"
+# but kaniko produces "blubb bla", indicating the previous ARG leaked.
+RUN echo "$ARG1 $ARG2" > out2
+
+FROM busybox
+COPY --from=base1 out1 out1
+COPY --from=base2 out2 out2
+RUN echo "$ARG1 $ARG2" > out3
+RUN cat out1 out2 out3

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -871,8 +871,9 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			args = stageArgs[stage.BaseImageIndex]
 		}
 		if args == nil {
-			logrus.Panic("stages must be processed in order and ars passed along")
+			logrus.Panicf("stages must be processed in order. base stage %d not yet in stageArgs", stage.BaseImageIndex)
 		}
+		// args is a pointer but is cloned inside newStageBuilder, so sharing it is safe.
 		sb, err := newStageBuilder(
 			args, opts, stage,
 			fileContext)

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -812,8 +812,8 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	}
 
 	lastStage := kanikoStages[len(kanikoStages)-1]
-	args := dockerfile.NewBuildArgs(opts.BuildArgs)
-	err = args.InitPredefinedArgs(opts.CustomPlatform, lastStage.Name)
+	baseArgs := dockerfile.NewBuildArgs(opts.BuildArgs)
+	err = baseArgs.InitPredefinedArgs(opts.CustomPlatform, lastStage.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -863,8 +863,16 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 		})
 	}
 
+	stageArgs := make([]*dockerfile.BuildArgs, lastStage.Index+1)
 	var pushImage v1.Image
 	for _, stage := range kanikoStages {
+		args := baseArgs
+		if stage.BaseImageIndex >= 0 {
+			args = stageArgs[stage.BaseImageIndex]
+		}
+		if args == nil {
+			logrus.Panic("stages must be processed in order and ars passed along")
+		}
 		sb, err := newStageBuilder(
 			args, opts, stage,
 			fileContext)
@@ -888,7 +896,7 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 			return nil, fmt.Errorf("failed to optimize instructions: %w", err)
 		}
 
-		args = sb.args
+		stageArgs[stage.Index] = sb.args
 		crossStageDeps := len(crossStageDependencies[stage.Index]) > 0
 		err = sb.build(*compositeKey, opts, fileContext, snapshotter, crossStageDeps)
 		if err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes https://github.com/osscontainertools/kaniko/issues/622

**Description**
`ARG` values were leaking across unrelated sibling stages. A stage could see `ARG` values declared in a preceding sibling even though it never declared that `ARG` itself and the two stages share no `FROM` ancestry. This diverges from Docker behaviour, where a stage only inherits `ARG` declarations from the stage it is directly based on.

Each stage now initialises its build args from its direct `FROM` ancestor only, matching Docker semantics. Multi-stage builds where sibling stages declare the same `ARG` name with different default values will now produce correct output. If you were accidentally relying on the leaked value, add an explicit `ARG` declaration to the affected stage.