### PR TITLE
1568: runCmdFilesUsedFromContext returned nil instead of empty slice

### DIFF
--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -528,7 +528,7 @@ func runCmdFilesUsedFromContext(
 ) ([]string, error) {
 	ff_bind := kConfig.EnvBool("FF_KANIKO_RUN_MOUNT_BIND")
 	if !ff_bind {
-		return nil, nil
+		return []string{}, nil
 	}
 
 	replacementEnvs := buildArgs.ReplacementEnvs(config.Env)

--- a/pkg/commands/run.go
+++ b/pkg/commands/run.go
@@ -539,7 +539,7 @@ func runCmdFilesUsedFromContext(
 		return nil, err
 	}
 
-	var files []string
+	files := []string{}
 	for _, m := range instructions.GetMounts(cmd) {
 		if m.Type != instructions.MountTypeBind {
 			continue


### PR DESCRIPTION
populateCompositeKey distinguishes between nil and an empty []string: a nil files slice means "no file context was provided" and triggers a panic, while a non-nil empty slice means "no context files needed" and passes through cleanly.

BaseCommand.FilesUsedFromContext correctly returns []string{}. runCmdFilesUsedFromContext violated the same contract by returning nil when FF_KANIKO_RUN_MOUNT_BIND is off, causing populateCompositeKey to panic for any plain RUN command during the optimize pass.

Fix: return []string{} instead of nil when the bind-mount flag is off.
