### PR TITLE
mz655: fix empty finalCacheKey for FROM-only stages

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_issue_mz655
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz655
@@ -1,0 +1,16 @@
+# mz655: FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY asserts when a COPY --from
+# targets a FROM-only stage whose source image changes between builds.
+# Build this twice with different BASE_TAG values to reproduce.
+ARG BASE_TAG
+FROM busybox:${BASE_TAG} AS src
+
+FROM scratch AS intermediate
+WORKDIR /same
+# assertion fires here because src is FROM-only: its finalCacheKey stays ""
+# so the inferred key for this COPY is identical across builds even when BASE_TAG changes.
+COPY --from=src /bin/busybox /diff
+
+FROM scratch
+# /same is an empty WORKDIR that washes out the version-specific /diff,
+# so the final image is identical regardless of BASE_TAG.
+COPY --from=intermediate /same /same

--- a/integration/images.go
+++ b/integration/images.go
@@ -70,7 +70,12 @@ var argsMap = map[string][]string{
 		"file=context/foo",
 		"file3=context/b*",
 	},
-	"Dockerfile_test_multistage": {"file=/foo2"},
+	"Dockerfile_test_multistage":  {"file=/foo2"},
+	"Dockerfile_test_issue_mz655": {"BASE_TAG=1.37.0"},
+}
+
+var argsMapVersion1 = map[string][]string{
+	"Dockerfile_test_issue_mz655": {"BASE_TAG=1.36.1"},
 }
 
 // Environment to build Dockerfiles with, used for both docker and kaniko builds
@@ -89,7 +94,6 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_mz473":                {"KANIKO_DIR=/kaniko2"},
 	"Dockerfile_test_issue_mz511":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz529":                {"FF_KANIKO_SQUASH_STAGES=0"},
-	"Dockerfile_test_issue_mz334":                {"FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY=1"},
 }
 
 var KanikoEnv = []string{
@@ -103,6 +107,7 @@ var KanikoEnv = []string{
 	"FF_KANIKO_PRESERVE_HARDLINKS=1",
 	"FF_KANIKO_BUILDKIT_ARG_ENV_PRECEDENCE=1",
 	"FF_KANIKO_RUN_MOUNT_BIND=1",
+	"FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY=1",
 }
 
 var WarmerEnv = []string{
@@ -173,6 +178,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_cache_copy":             {"--cache-copy-layers=true"},
 	"Dockerfile_test_cache_copy_oci":         {"--cache-copy-layers=true"},
 	"Dockerfile_test_issue_add":              {"--cache-copy-layers=true"},
+	"Dockerfile_test_issue_mz655":            {"--cache-copy-layers=true"},
 	"Dockerfile_test_volume_3":               {"--skip-unused-stages=false"},
 	"Dockerfile_test_multistage":             {"--skip-unused-stages=false"},
 	"Dockerfile_test_copy_root_multistage":   {"--skip-unused-stages=false"},
@@ -394,6 +400,7 @@ func NewDockerFileBuilder() *DockerFileBuilder {
 		"Dockerfile_test_issue_empty":   {},
 		"Dockerfile_test_issue_mz637":   {},
 		"Dockerfile_test_issue_mz334":   {},
+		"Dockerfile_test_issue_mz655":   {},
 	}
 	d.TestOCICacheDockerfiles = map[string]struct{}{
 		"Dockerfile_test_cache_oci":         {},
@@ -616,6 +623,19 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}
+
+	rawBuildArgs := argsMap[dockerfile]
+	if version == 1 {
+		if override, ok := argsMapVersion1[dockerfile]; ok {
+			rawBuildArgs = override
+		}
+	}
+	var buildArgs []string
+	for _, arg := range rawBuildArgs {
+		buildArgs = append(buildArgs, "--build-arg", arg)
+	}
+	buildArgs = append(buildArgs, "--build-arg", "IMAGE_REPO="+config.imageRepo)
+
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
@@ -625,6 +645,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 		"--cache-repo", cacheRepo,
 		"--cache-dir", cacheDir)
 	dockerRunFlags = append(dockerRunFlags, args...)
+	dockerRunFlags = append(dockerRunFlags, buildArgs...)
 	kanikoCmd := exec.Command("docker", dockerRunFlags...)
 
 	out, err := RunCommandWithoutTest(kanikoCmd)

--- a/integration/images.go
+++ b/integration/images.go
@@ -625,10 +625,8 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	}
 
 	rawBuildArgs := argsMap[dockerfile]
-	if version == 1 {
-		if override, ok := argsMapVersion1[dockerfile]; ok {
-			rawBuildArgs = override
-		}
+	if override, ok := argsMapVersion1[dockerfile]; version == 1 && ok {
+		rawBuildArgs = override
 	}
 	var buildArgs []string
 	for _, arg := range rawBuildArgs {

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -372,6 +372,10 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 			}
 		}
 	}
+
+	if finalCacheKey == "" {
+		logrus.Panic("Unreachable: finalCacheKey can't be empty")
+	}
 	return finalCacheKey, nil
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -294,7 +294,10 @@ func (s *stageBuilder) optimize(compositeKey CompositeCache, cfg v1.Config, opts
 	}()
 
 	stopCache := false
-	finalCacheKey := ""
+	finalCacheKey, err := compositeKey.Hash()
+	if err != nil {
+		return "", err
+	}
 	// Possibly replace commands with their cached implementations.
 	// We walk through all the commands, running any commands that only operate on metadata.
 	// We throw the metadata away after, but we need it to properly track command dependencies


### PR DESCRIPTION
fixes https://github.com/osscontainertools/kaniko/issues/655
continuation of https://github.com/osscontainertools/kaniko/pull/618

Fixes a panic in `FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY` when a `COPY --from` targets a FROM-only stage and the source image changes between builds (e.g. via a different `--build-arg`).

**Root cause**

`optimize()` initialised `finalCacheKey` to `""` and only updated it inside the command loop. FROM-only stages have no commands, so the loop never runs and `stageFinalCacheKeys` ends up mapping those stages to `""`. All FROM-only stages then share the same inferred cross-stage cache key regardless of which image was actually used. On a subsequent build with a different source image the stored pointer no longer matches the recomputed content key and kaniko panics.

**Fix**

Seed `finalCacheKey` with the hash of the initial `compositeKey` (the base image digest) before entering the loop. FROM-only stages then return a key that actually identifies the image they pulled, so inferred keys for downstream `COPY --from` commands correctly differ when the source image changes.

An assertion that `finalCacheKey != ""` at the end of `optimize()` guards against this regression.
