### PR TITLE
mz658: kaniko-alpine riscv64 build failure

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -115,7 +115,11 @@ FROM alpine AS kaniko-alpine
 RUN apk add --no-cache ca-certificates git
 
 COPY --from=builder /src/out/executor /kaniko/executor
-COPY --from=kaniko-base-2 /kaniko/tini /kaniko/tini
+
+# mz446: there is no tini binary release on riscv64
+ARG TARGETARCH
+RUN --mount=from=kaniko-base-2,source=/kaniko,target=/mnt/kaniko \
+    [ "$TARGETARCH" = "riscv64" ] || cp /mnt/kaniko/tini /kaniko/tini
 
 # mz595: pre-existing alpine files would result in invalid build outputs.
 # with these flags we wipe the filesystem before build, circumventing this issue.


### PR DESCRIPTION
## Summary

Fixes #658.

The `kaniko-alpine` image failed to build on `riscv64` because it unconditionally copied `/kaniko/tini` from `kaniko-base-2`. On `riscv64`, `kaniko-base-2` resolves to `kaniko-base-riscv64` — a stage that intentionally omits tini since [no riscv64 release exists](https://github.com/krallin/tini/releases). The `COPY` therefore referenced a file that didn't exist.

`kaniko-executor` was already correct because it inherits from `kaniko-base-2` directly and never does a file-level copy of tini. Only `kaniko-alpine` was broken.

## Change

Replace the unconditional `COPY` with a `RUN --mount=from=kaniko-base-2` that conditionally copies tini only when `TARGETARCH != riscv64`. Since `kaniko-alpine` is FROM alpine it has a shell, so this is simpler than duplicating the existing arch-split alias pattern used for `kaniko-base`.

```dockerfile
# before
COPY --from=kaniko-base-2 /kaniko/tini /kaniko/tini

# after
ARG TARGETARCH
RUN --mount=from=kaniko-base-2,source=/kaniko,target=/mnt/kaniko \
    [ "$TARGETARCH" = "riscv64" ] || cp /mnt/kaniko/tini /kaniko/tini
```

## Test plan

- [ ] Build `kaniko-alpine` for `linux/riscv64` — should succeed and produce an image without `/kaniko/tini`
- [ ] Build `kaniko-alpine` for `linux/amd64`, `linux/arm64` — should succeed and produce an image with `/kaniko/tini`