### PR TITLE
coverage report

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,7 @@
+flags:
+  unit:
+    carryforward: true
+  golden:
+    carryforward: true
+  integration:
+    carryforward: true

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,0 @@
-flags:
-  unit:
-    carryforward: true
-  golden:
-    carryforward: true
-  integration:
-    carryforward: true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Merge and convert coverage
         run: |
           mkdir -p covdata-merged
-          parts=$(find covdata-parts -mindepth 1 -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
+          parts=$(find covdata-parts -mindepth 1 -maxdepth 1 -type d | tr '\n' ',' | sed 's/,$//')
           if [[ -z "$parts" ]]; then
             echo "No coverage data found, skipping merge"
             exit 0

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -83,7 +83,7 @@ jobs:
           check-latest: true
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: covdata-*
           path: covdata-parts/

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -39,14 +39,14 @@ jobs:
           remove-dotnet: 'true'
           remove-haskell: 'true'
 
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
           check-latest: true
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
 
       - uses: docker/setup-docker-action@b2189fbf2a6592b51fee7cdd93ee2bfaeba733db # v5.1.0
         with:
@@ -72,6 +72,10 @@ jobs:
       contents: read
 
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,11 +25,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        make-target:
-          - integration-test-layers
-          - integration-test-misc
-          - integration-test-run
-          - k8s-executor-build-push integration-test-k8s
+        include:
+          - make-target: integration-test-layers
+            artifact-name: layers
+          - make-target: integration-test-misc
+            artifact-name: misc
+          - make-target: integration-test-run
+            artifact-name: run
+          - make-target: k8s-executor-build-push integration-test-k8s
+            artifact-name: k8s
 
     steps:
       - name: Maximize build space
@@ -59,7 +63,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: covdata-${{ matrix.make-target }}
+          name: covdata-${{ matrix.artifact-name }}
           path: out/covdata-merged/
           if-no-files-found: ignore
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,6 +20,7 @@ jobs:
     env:
       IMAGE_REPO: 'localhost:5000'
       REGISTRY: 'localhost:5000'
+      COVERAGE_DIR: 'out/covdata'
 
     strategy:
       fail-fast: false
@@ -53,3 +54,54 @@ jobs:
 
       - run: make install-diffoci k3s-setup
       - run: make ${{ matrix.make-target }}
+
+      - name: Upload coverage data
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: covdata-${{ matrix.make-target }}
+          path: out/covdata-merged/
+          if-no-files-found: ignore
+
+  coverage-merge:
+    name: Merge integration coverage
+    runs-on: ubuntu-latest
+    needs: tests
+    if: always()
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.26.2'
+          check-latest: true
+
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: covdata-*
+          path: covdata-parts/
+          merge-multiple: false
+
+      - name: Merge and convert coverage
+        run: |
+          mkdir -p covdata-merged
+          parts=$(find covdata-parts -mindepth 1 -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
+          if [[ -z "$parts" ]]; then
+            echo "No coverage data found, skipping merge"
+            exit 0
+          fi
+          go tool covdata merge -i "$parts" -o covdata-merged
+          go tool covdata textfmt -i covdata-merged -o coverage-integration.txt
+          go tool cover -html=coverage-integration.txt -o coverage-integration.html
+
+      - name: Upload merged coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: integration-coverage-report
+          path: |
+            coverage-integration.txt
+            coverage-integration.html
+          if-no-files-found: ignore

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       IMAGE_REPO: 'localhost:5000'
       REGISTRY: 'localhost:5000'
-      COVERAGE_DIR: 'out/covdata'
+      COVERAGE_DIR: '${{ github.workspace }}/out/covdata'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: covdata-${{ strategy.job-index }}
-          path: out/covdata-merged/
+          path: out/covdata/
           if-no-files-found: ignore
 
   coverage-merge:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -67,7 +67,6 @@ jobs:
     name: Merge integration coverage
     runs-on: ubuntu-latest
     needs: tests
-    if: always()
 
     permissions:
       contents: read

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,15 +25,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - make-target: integration-test-layers
-            artifact-name: layers
-          - make-target: integration-test-misc
-            artifact-name: misc
-          - make-target: integration-test-run
-            artifact-name: run
-          - make-target: k8s-executor-build-push integration-test-k8s
-            artifact-name: k8s
+        make-target:
+          - integration-test-layers
+          - integration-test-misc
+          - integration-test-run
+          - k8s-executor-build-push integration-test-k8s
 
     steps:
       - name: Maximize build space
@@ -63,7 +59,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: covdata-${{ matrix.artifact-name }}
+          name: covdata-${{ strategy.job-index }}
           path: out/covdata-merged/
           if-no-files-found: ignore
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -56,14 +56,12 @@ jobs:
       - run: make ${{ matrix.make-target }}
 
       - name: Convert and upload coverage
-        if: always()
         run: |
           if compgen -G "out/covdata/*" > /dev/null 2>&1; then
             go tool covdata textfmt -i out/covdata -o coverage.txt
           fi
 
-      - uses: codecov/codecov-action@v5
-        if: always()
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: coverage.txt
           flags: integration

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -39,14 +39,14 @@ jobs:
           remove-dotnet: 'true'
           remove-haskell: 'true'
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
           check-latest: true
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: docker/setup-docker-action@b2189fbf2a6592b51fee7cdd93ee2bfaeba733db # v5.1.0
         with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -55,58 +55,16 @@ jobs:
       - run: make install-diffoci k3s-setup
       - run: make ${{ matrix.make-target }}
 
-      - name: Upload coverage data
+      - name: Convert and upload coverage
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: covdata-${{ strategy.job-index }}
-          path: out/covdata/
-          if-no-files-found: ignore
-
-  coverage-merge:
-    name: Merge integration coverage
-    runs-on: ubuntu-latest
-    needs: tests
-
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: '1.26.2'
-          check-latest: true
-
-      - name: Download all coverage artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          pattern: covdata-*
-          path: covdata-parts/
-          merge-multiple: false
-
-      - name: Merge and convert coverage
         run: |
-          mkdir -p covdata-merged
-          parts=$(find covdata-parts -mindepth 1 -maxdepth 1 -type d | tr '\n' ',' | sed 's/,$//')
-          if [[ -z "$parts" ]]; then
-            echo "No coverage data found, skipping merge"
-            exit 0
+          if compgen -G "out/covdata/*" > /dev/null 2>&1; then
+            go tool covdata textfmt -i out/covdata -o coverage.txt
           fi
-          go tool covdata merge -i "$parts" -o covdata-merged
-          go tool covdata textfmt -i covdata-merged -o coverage-integration.txt
-          go tool cover -html=coverage-integration.txt -o coverage-integration.html
-          pct=$(go tool cover -func=coverage-integration.txt | tail -1 | awk '{print $NF}')
-          echo "## Integration test coverage: $pct" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload merged coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: codecov/codecov-action@v5
+        if: always()
         with:
-          name: integration-coverage-report
-          path: |
-            coverage-integration.txt
-            coverage-integration.html
-          if-no-files-found: ignore
+          files: coverage.txt
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -57,9 +57,7 @@ jobs:
 
       - name: Convert and upload coverage
         run: |
-          if compgen -G "out/covdata/*" > /dev/null 2>&1; then
-            go tool covdata textfmt -i out/covdata -o coverage.txt
-          fi
+          go tool covdata textfmt -i out/covdata -o coverage.txt
 
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -99,6 +99,8 @@ jobs:
           go tool covdata merge -i "$parts" -o covdata-merged
           go tool covdata textfmt -i covdata-merged -o coverage-integration.txt
           go tool cover -html=coverage-integration.txt -o coverage-integration.html
+          pct=$(go tool cover -func=coverage-integration.txt | tail -1 | awk '{print $NF}')
+          echo "## Integration test coverage: $pct" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload merged coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -66,5 +66,6 @@ jobs:
         if: always()
         with:
           files: coverage.txt
+          flags: integration
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,6 +64,5 @@ jobs:
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: coverage.txt
-          flags: integration
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -34,9 +34,23 @@ jobs:
 
       - run: make test
 
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          files: out/coverage.out
+          flags: unit
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - run: make golden
 
-      - name: Run staticcheck 
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          files: out/coverage.out
+          flags: golden
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1.4.1
         with:
           install-go: false

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -34,21 +34,7 @@ jobs:
 
       - run: make test
 
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: out/coverage.out
-          flags: unit
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
       - run: make golden
-
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          files: out/coverage.out
-          flags: golden
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1.4.1

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ export GOFLAGS = -mod=vendor
 
 
 out/executor: $(GO_FILES)
-	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build $(if $(COVER),-cover) -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
+	GOFLAGS= GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build $(if $(COVER),-cover) -mod=vendor -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
 
 out/warmer: $(GO_FILES)
 	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)

--- a/Makefile
+++ b/Makefile
@@ -102,12 +102,12 @@ integration-test-misc:
 .PHONY: integration-test-coverage
 integration-test-coverage:
 	$(eval RUN_ARG=$(shell ./scripts/misc-integration-test.sh))
-	COVERAGE_DIR=out/covdata-misc LOCAL=1 ./scripts/integration-test.sh -run "$(RUN_ARG)"
-	COVERAGE_DIR=out/covdata-run  LOCAL=1 ./scripts/integration-test.sh -run "TestRun"
-	COVERAGE_DIR=out/covdata-layers LOCAL=1 ./scripts/integration-test.sh -run "TestLayers"
-	mkdir -p out/covdata-merged
-	go tool covdata merge -i out/covdata-misc-merged:out/covdata-run-merged:out/covdata-layers-merged -o out/covdata-merged
-	go tool covdata textfmt -i out/covdata-merged -o out/coverage-integration.txt
+	COVERAGE_DIR=out/covdata/misc   LOCAL=1 ./scripts/integration-test.sh -run "$(RUN_ARG)"
+	COVERAGE_DIR=out/covdata/run    LOCAL=1 ./scripts/integration-test.sh -run "TestRun"
+	COVERAGE_DIR=out/covdata/layers LOCAL=1 ./scripts/integration-test.sh -run "TestLayers"
+	mkdir -p out/covdata/merged
+	go tool covdata merge -i out/covdata/misc-merged:out/covdata/run-merged:out/covdata/layers-merged -o out/covdata/merged
+	go tool covdata textfmt -i out/covdata/merged -o out/coverage-integration.txt
 	go tool cover -html=out/coverage-integration.txt -o out/coverage-integration.html
 	@echo "Integration coverage report: out/coverage-integration.html"
 

--- a/Makefile
+++ b/Makefile
@@ -99,17 +99,6 @@ integration-test-misc:
 	$(eval RUN_ARG=$(shell ./scripts/misc-integration-test.sh))
 	@ ./scripts/integration-test.sh -run "$(RUN_ARG)"
 
-.PHONY: integration-test-coverage
-integration-test-coverage:
-	$(eval RUN_ARG=$(shell ./scripts/misc-integration-test.sh))
-	COVERAGE_DIR=out/covdata/misc   LOCAL=1 ./scripts/integration-test.sh -run "$(RUN_ARG)"
-	COVERAGE_DIR=out/covdata/run    LOCAL=1 ./scripts/integration-test.sh -run "TestRun"
-	COVERAGE_DIR=out/covdata/layers LOCAL=1 ./scripts/integration-test.sh -run "TestLayers"
-	mkdir -p out/covdata/merged
-	go tool covdata merge -i out/covdata/misc-merged:out/covdata/run-merged:out/covdata/layers-merged -o out/covdata/merged
-	go tool covdata textfmt -i out/covdata/merged -o out/coverage-integration.txt
-	go tool cover -html=out/coverage-integration.txt -o out/coverage-integration.html
-	@echo "Integration coverage report: out/coverage-integration.html"
 
 .PHONY: k8s-executor-build-push
 k8s-executor-build-push:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ EXECUTOR_PACKAGE = $(REPOPATH)/cmd/executor
 WARMER_PACKAGE = $(REPOPATH)/cmd/warmer
 KANIKO_PROJECT = $(REPOPATH)/kaniko
 BUILD_ARG ?=
+COVER ?=
 
 # Force using Go Modules and always read the dependencies from
 # the `vendor` folder.
@@ -48,7 +49,7 @@ export GOFLAGS = -mod=vendor
 
 
 out/executor: $(GO_FILES)
-	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
+	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build $(if $(COVER),-cover) -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
 
 out/warmer: $(GO_FILES)
 	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ integration-test-misc:
 	$(eval RUN_ARG=$(shell ./scripts/misc-integration-test.sh))
 	@ ./scripts/integration-test.sh -run "$(RUN_ARG)"
 
-
 .PHONY: k8s-executor-build-push
 k8s-executor-build-push:
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) --build-arg=TARGETOS=linux -t $(REGISTRY)/executor:latest -f deploy/Dockerfile --target kaniko-executor .

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,18 @@ integration-test-misc:
 	$(eval RUN_ARG=$(shell ./scripts/misc-integration-test.sh))
 	@ ./scripts/integration-test.sh -run "$(RUN_ARG)"
 
+.PHONY: integration-test-coverage
+integration-test-coverage:
+	$(eval RUN_ARG=$(shell ./scripts/misc-integration-test.sh))
+	COVERAGE_DIR=out/covdata-misc LOCAL=1 ./scripts/integration-test.sh -run "$(RUN_ARG)"
+	COVERAGE_DIR=out/covdata-run  LOCAL=1 ./scripts/integration-test.sh -run "TestRun"
+	COVERAGE_DIR=out/covdata-layers LOCAL=1 ./scripts/integration-test.sh -run "TestLayers"
+	mkdir -p out/covdata-merged
+	go tool covdata merge -i out/covdata-misc-merged:out/covdata-run-merged:out/covdata-layers-merged -o out/covdata-merged
+	go tool covdata textfmt -i out/covdata-merged -o out/coverage-integration.txt
+	go tool cover -html=out/coverage-integration.txt -o out/coverage-integration.html
+	@echo "Integration coverage report: out/coverage-integration.html"
+
 .PHONY: k8s-executor-build-push
 k8s-executor-build-push:
 	docker build ${BUILD_ARG} --build-arg=GOARCH=$(GOARCH) --build-arg=TARGETOS=linux -t $(REGISTRY)/executor:latest -f deploy/Dockerfile --target kaniko-executor .

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ GO_LDFLAGS += -X $(VERSION_PACKAGE).version=$(VERSION)
 GO_LDFLAGS += -w -s # Drop debugging symbols.
 GO_LDFLAGS += '
 
-EXECUTOR_PACKAGE = $(REPOPATH)/cmd/executor
-WARMER_PACKAGE = $(REPOPATH)/cmd/warmer
+EXECUTOR_PACKAGE = ./cmd/executor
+WARMER_PACKAGE = ./cmd/warmer
 KANIKO_PROJECT = $(REPOPATH)/kaniko
 BUILD_ARG ?=
 COVER ?=

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ GO_LDFLAGS += -X $(VERSION_PACKAGE).version=$(VERSION)
 GO_LDFLAGS += -w -s # Drop debugging symbols.
 GO_LDFLAGS += '
 
-EXECUTOR_PACKAGE = ./cmd/executor
-WARMER_PACKAGE = ./cmd/warmer
+EXECUTOR_PACKAGE = $(REPOPATH)/cmd/executor
+WARMER_PACKAGE = $(REPOPATH)/cmd/warmer
 KANIKO_PROJECT = $(REPOPATH)/kaniko
 BUILD_ARG ?=
 COVER ?=
@@ -49,7 +49,7 @@ export GOFLAGS = -mod=vendor
 
 
 out/executor: $(GO_FILES)
-	GOFLAGS= GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build $(if $(COVER),-cover) -mod=vendor -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
+	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build $(if $(COVER),-cover) -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
 
 out/warmer: $(GO_FILES)
 	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ out/executor: $(GO_FILES)
 	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build $(if $(COVER),-cover) -ldflags $(GO_LDFLAGS) -o $@ $(EXECUTOR_PACKAGE)
 
 out/warmer: $(GO_FILES)
-	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)
+	GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build $(if $(COVER),-cover) -ldflags $(GO_LDFLAGS) -o $@ $(WARMER_PACKAGE)
 
 .PHONY: install-diffoci
 install-diffoci:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Integration tests](https://github.com/osscontainertools/kaniko/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/osscontainertools/kaniko/actions/workflows/integration-tests.yaml)
 [![Build images](https://github.com/osscontainertools/kaniko/actions/workflows/images.yaml/badge.svg)](https://github.com/osscontainertools/kaniko/actions/workflows/images.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/osscontainertools/kaniko)](https://goreportcard.com/report/github.com/osscontainertools/kaniko)
+[![codecov](https://codecov.io/gh/osscontainertools/kaniko/graph/badge.svg)](https://codecov.io/gh/osscontainertools/kaniko)
 
 ![kaniko logo](logo/Kaniko-Logo.png)
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -47,8 +47,7 @@ RUN go build -o out/ github.com/GoogleCloudPlatform/docker-credential-gcr/v2 \
 
 COPY . .
 ARG COVER=""
-RUN make out/executor out/warmer \
-    && if [ -n "$COVER" ]; then CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -cover -o out/executor github.com/osscontainertools/kaniko/cmd/executor; fi \
+RUN make COVER="$COVER" out/executor out/warmer \
     && rm -rf /root/.cache
 
 # Generate latest ca-certificates

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -96,6 +96,10 @@ FROM kaniko-base-tini AS kaniko-base-ppc64le
 FROM kaniko-base AS kaniko-base-riscv64
 FROM kaniko-base-${TARGETARCH} AS kaniko-base-2
 
+FROM builder AS builder-coverage
+RUN CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -cover -o out/executor-coverage github.com/osscontainertools/kaniko/cmd/executor \
+    && rm -rf /root/.cache
+
 ### FINAL STAGES ###
 
 FROM kaniko-base AS kaniko-warmer
@@ -127,6 +131,10 @@ ENV KANIKO_PRESERVE_CONTEXT=1 \
     KANIKO_PRE_CLEANUP=1
 
 ENTRYPOINT ["/kaniko/executor"]
+
+FROM kaniko-executor AS kaniko-executor-coverage
+
+COPY --from=builder-coverage /src/out/executor-coverage /kaniko/executor
 
 FROM kaniko-executor AS kaniko-debug
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -46,7 +46,9 @@ RUN go build -o out/ github.com/GoogleCloudPlatform/docker-credential-gcr/v2 \
     && rm -rf /root/.cache /go/pkg
 
 COPY . .
+ARG COVER=""
 RUN make out/executor out/warmer \
+    && if [ -n "$COVER" ]; then CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -cover -o out/executor github.com/osscontainertools/kaniko/cmd/executor; fi \
     && rm -rf /root/.cache
 
 # Generate latest ca-certificates
@@ -96,10 +98,6 @@ FROM kaniko-base-tini AS kaniko-base-ppc64le
 FROM kaniko-base AS kaniko-base-riscv64
 FROM kaniko-base-${TARGETARCH} AS kaniko-base-2
 
-FROM builder AS builder-coverage
-RUN CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -cover -o out/executor-coverage github.com/osscontainertools/kaniko/cmd/executor \
-    && rm -rf /root/.cache
-
 ### FINAL STAGES ###
 
 FROM kaniko-base AS kaniko-warmer
@@ -131,10 +129,6 @@ ENV KANIKO_PRESERVE_CONTEXT=1 \
     KANIKO_PRE_CLEANUP=1
 
 ENTRYPOINT ["/kaniko/executor"]
-
-FROM kaniko-executor AS kaniko-executor-coverage
-
-COPY --from=builder-coverage /src/out/executor-coverage /kaniko/executor
 
 FROM kaniko-executor AS kaniko-debug
 

--- a/integration/images.go
+++ b/integration/images.go
@@ -51,10 +51,9 @@ const (
 	cacheDir         = "/workspace/cache"
 	baseImageToCache = "debian:12.10@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56"
 
-	ExecutorImageMoved    = "executor-image-moved"
-	ExecutorImageTainted  = "executor-image-tainted"
-	ExecutorImageCoverage = "executor-image-coverage"
-	AlpineImage           = "alpine-image"
+	ExecutorImageMoved   = "executor-image-moved"
+	ExecutorImageTainted = "executor-image-tainted"
+	AlpineImage          = "alpine-image"
 )
 
 var coverageDir string
@@ -64,13 +63,6 @@ func addCoverageFlags(flags []string) []string {
 		return flags
 	}
 	return append(flags, "-v", coverageDir+":/kaniko/covdata", "-e", "GOCOVERDIR=/kaniko/covdata")
-}
-
-func activeExecutorImage() string {
-	if coverageDir != "" {
-		return ExecutorImageCoverage
-	}
-	return ExecutorImage
 }
 
 // Arguments to build Dockerfiles with, used for both docker and kaniko builds
@@ -642,7 +634,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	for _, envVariable := range envsMap[dockerfile] {
 		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
-	executorImage := activeExecutorImage()
+	executorImage := ExecutorImage
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}
@@ -714,7 +706,7 @@ func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTes
 	for _, envVariable := range KanikoEnv {
 		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
-	executorImage := activeExecutorImage()
+	executorImage := ExecutorImage
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}
@@ -785,7 +777,7 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 	for _, envVariable := range KanikoEnv {
 		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
-	executorImage := activeExecutorImage()
+	executorImage := ExecutorImage
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}
@@ -879,7 +871,7 @@ func buildKanikoImage(
 		kanikoDockerfilePath = path.Join(buildContextPath, "Dockerfile")
 	}
 
-	executorImage := activeExecutorImage()
+	executorImage := ExecutorImage
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}

--- a/integration/images.go
+++ b/integration/images.go
@@ -590,6 +590,7 @@ func populateVolumeCache(logf logger, serviceAccount string) error {
 		cmd = append(cmd, "-e", envVariable)
 	}
 	cmd = addServiceAccountFlags(cmd, serviceAccount)
+	cmd = addCoverageFlags(cmd)
 	cmd = append(cmd,
 		WarmerImage,
 		"-c", cacheDir,

--- a/integration/images.go
+++ b/integration/images.go
@@ -51,10 +51,27 @@ const (
 	cacheDir         = "/workspace/cache"
 	baseImageToCache = "debian:12.10@sha256:264982ff4d18000fa74540837e2c43ca5137a53a83f8f62c7b3803c0f0bdcd56"
 
-	ExecutorImageMoved   = "executor-image-moved"
-	ExecutorImageTainted = "executor-image-tainted"
-	AlpineImage          = "alpine-image"
+	ExecutorImageMoved    = "executor-image-moved"
+	ExecutorImageTainted  = "executor-image-tainted"
+	ExecutorImageCoverage = "executor-image-coverage"
+	AlpineImage           = "alpine-image"
 )
+
+var coverageDir string
+
+func addCoverageFlags(flags []string) []string {
+	if coverageDir == "" {
+		return flags
+	}
+	return append(flags, "-v", coverageDir+":/kaniko/covdata", "-e", "GOCOVERDIR=/kaniko/covdata")
+}
+
+func activeExecutorImage() string {
+	if coverageDir != "" {
+		return ExecutorImageCoverage
+	}
+	return ExecutorImage
+}
 
 // Arguments to build Dockerfiles with, used for both docker and kaniko builds
 var argsMap = map[string][]string{
@@ -625,7 +642,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	for _, envVariable := range envsMap[dockerfile] {
 		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
-	executorImage := ExecutorImage
+	executorImage := activeExecutorImage()
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}
@@ -641,6 +658,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	buildArgs = append(buildArgs, "--build-arg", "IMAGE_REPO="+config.imageRepo)
 
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
 		"-d", kanikoImage,
@@ -696,11 +714,12 @@ func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTes
 	for _, envVariable := range KanikoEnv {
 		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
-	executorImage := ExecutorImage
+	executorImage := activeExecutorImage()
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
 		"-d", kanikoImage,
@@ -766,11 +785,12 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 	for _, envVariable := range KanikoEnv {
 		dockerRunFlags = append(dockerRunFlags, "-e", envVariable)
 	}
-	executorImage := ExecutorImage
+	executorImage := activeExecutorImage()
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -859,11 +879,12 @@ func buildKanikoImage(
 		kanikoDockerfilePath = path.Join(buildContextPath, "Dockerfile")
 	}
 
-	executorImage := ExecutorImage
+	executorImage := activeExecutorImage()
 	if exec, ok := executorImages[dockerfile]; ok {
 		executorImage = exec
 	}
 
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", kanikoDockerfilePath,
 		"-d", kanikoImage,

--- a/integration/images.go
+++ b/integration/images.go
@@ -58,8 +58,8 @@ const (
 
 var coverageDir string
 
-func addCoverageFlags(flags []string) []string {
-	if coverageDir == "" {
+func addCoverageFlags(flags []string, executorImage string) []string {
+	if coverageDir == "" || executorImage != ExecutorImage {
 		return flags
 	}
 	return append(flags, "-v", coverageDir+":/kaniko/covdata", "-e", "GOCOVERDIR=/kaniko/covdata")
@@ -650,7 +650,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	buildArgs = append(buildArgs, "--build-arg", "IMAGE_REPO="+config.imageRepo)
 
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, executorImage)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
 		"-d", kanikoImage,
@@ -711,7 +711,7 @@ func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTes
 		executorImage = exec
 	}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, executorImage)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
 		"-d", kanikoImage,
@@ -782,7 +782,7 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 		executorImage = exec
 	}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, executorImage)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -876,7 +876,7 @@ func buildKanikoImage(
 		executorImage = exec
 	}
 
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, executorImage)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", kanikoDockerfilePath,
 		"-d", kanikoImage,

--- a/integration/images.go
+++ b/integration/images.go
@@ -58,11 +58,11 @@ const (
 
 var coverageDir string
 
-func addCoverageFlags(flags []string, executorImage string) []string {
-	if coverageDir == "" || executorImage != ExecutorImage {
+func addCoverageFlags(flags []string) []string {
+	if coverageDir == "" {
 		return flags
 	}
-	return append(flags, "-v", coverageDir+":/kaniko/covdata", "-e", "GOCOVERDIR=/kaniko/covdata")
+	return append(flags, "-v", coverageDir+":/covdata", "-e", "GOCOVERDIR=/covdata")
 }
 
 // Arguments to build Dockerfiles with, used for both docker and kaniko builds
@@ -650,7 +650,7 @@ func (d *DockerFileBuilder) buildCachedImage(logf logger, config *integrationTes
 	buildArgs = append(buildArgs, "--build-arg", "IMAGE_REPO="+config.imageRepo)
 
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, executorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
 		"-d", kanikoImage,
@@ -711,7 +711,7 @@ func (d *DockerFileBuilder) buildWarmerImage(logf logger, config *integrationTes
 		executorImage = exec
 	}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, executorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", path.Join(buildContextPath, dockerfilesPath, dockerfile),
 		"-d", kanikoImage,
@@ -782,7 +782,7 @@ func (d *DockerFileBuilder) buildRelativePathsImage(logf logger, imageRepo, dock
 		executorImage = exec
 	}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, executorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -876,7 +876,7 @@ func buildKanikoImage(
 		executorImage = exec
 	}
 
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, executorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, executorImage,
 		"-f", kanikoDockerfilePath,
 		"-d", kanikoImage,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -133,14 +133,15 @@ func TestMain(m *testing.M) {
 }
 
 func buildRequiredImages() error {
-	kanikoImageTarget := "kaniko-executor"
-	kanikoImageTag := ExecutorImage
 	if coverageDir != "" {
-		kanikoImageTarget = "kaniko-executor-coverage"
-		kanikoImageTag = ExecutorImageCoverage
 		if err := os.MkdirAll(coverageDir, 0o777); err != nil {
 			return fmt.Errorf("failed to create coverage dir %s: %w", coverageDir, err)
 		}
+	}
+
+	kanikoImageBuildCmd := []string{"docker", "build", "-t", ExecutorImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-executor", ".."}
+	if coverageDir != "" {
+		kanikoImageBuildCmd = []string{"docker", "build", "-t", ExecutorImage, "--build-arg", "COVER=1", "-f", "../deploy/Dockerfile", "--target", "kaniko-executor", ".."}
 	}
 
 	setupCommands := []struct {
@@ -148,7 +149,7 @@ func buildRequiredImages() error {
 		command []string
 	}{{
 		name:    "Building kaniko image",
-		command: []string{"docker", "build", "-t", kanikoImageTag, "-f", "../deploy/Dockerfile", "--target", kanikoImageTarget, ".."},
+		command: kanikoImageBuildCmd,
 	}, {
 		name:    "Building cache warmer image",
 		command: []string{"docker", "build", "-t", WarmerImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-warmer", ".."},
@@ -314,7 +315,7 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"-c", KanikoGitRepo(url, commit, branch))
@@ -387,7 +388,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(
 		dockerRunFlags,
-		activeExecutorImage(),
+		ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"-c", KanikoGitRepo(url, "", branch),
@@ -429,7 +430,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--registry-mirror", "doesnotexist.example.com",
@@ -471,7 +472,7 @@ func TestBuildViaRegistryMap(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--registry-map", "index.docker.io=doesnotexist.example.com",
@@ -498,7 +499,7 @@ func TestBuildSkipFallback(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--registry-mirror", "doesnotexist.example.com",
@@ -539,7 +540,7 @@ func TestKanikoDir(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--kaniko-dir", "/not-kaniko",
@@ -583,7 +584,7 @@ func TestBuildWithLabels(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--label", testLabel,
@@ -624,7 +625,7 @@ func TestBuildWithHTTPError(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"-c", KanikoGitRepo(url, "", branch),
@@ -980,7 +981,7 @@ func TestExitCodePropagation(t *testing.T) {
 		}
 		dockerFlags = addServiceAccountFlags(dockerFlags, "")
 		dockerFlags = addCoverageFlags(dockerFlags)
-		dockerFlags = append(dockerFlags, activeExecutorImage(),
+		dockerFlags = append(dockerFlags, ExecutorImage,
 			"-c", "dir:///workspace/",
 			"-f", "./Dockerfile_exit_code_propagation",
 			"--no-push",
@@ -1033,7 +1034,7 @@ func TestBuildWithAnnotations(t *testing.T) {
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
 	dockerRunFlags = addCoverageFlags(dockerRunFlags)
-	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
+	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--annotation", fmt.Sprintf("%s=%s", annotationKey, annotationValue),

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -139,42 +139,41 @@ func buildRequiredImages() error {
 		}
 	}
 
-	kanikoImageBuildCmd := []string{"docker", "build", "-t", ExecutorImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-executor"}
+	coverArg := "--build-arg=COVER=0"
 	if coverageDir != "" {
-		kanikoImageBuildCmd = append(kanikoImageBuildCmd, "--build-arg", "COVER=1")
+		coverArg = "--build-arg=COVER=1"
 	}
-	kanikoImageBuildCmd = append(kanikoImageBuildCmd, "..")
 
 	setupCommands := []struct {
 		name    string
 		command []string
 	}{{
 		name:    "Building kaniko image",
-		command: kanikoImageBuildCmd,
+		command: []string{"docker", "build", coverArg, "-t", ExecutorImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-executor", ".."},
 	}, {
 		name:    "Building cache warmer image",
-		command: []string{"docker", "build", "-t", WarmerImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-warmer", ".."},
+		command: []string{"docker", "build", coverArg, "-t", WarmerImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-warmer", ".."},
 	}, {
 		name:    "Building onbuild base image",
-		command: []string{"docker", "build", "--push", "-t", config.onbuildBaseImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_base", "."},
+		command: []string{"docker", "build", coverArg, "--push", "-t", config.onbuildBaseImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_base", "."},
 	}, {
 		name:    "Building onbuild copy image",
-		command: []string{"docker", "build", "--push", "-t", config.onbuildCopyImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_copy", "."},
+		command: []string{"docker", "build", coverArg, "--push", "-t", config.onbuildCopyImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_copy", "."},
 	}, {
 		name:    "Building hardlink base image",
-		command: []string{"docker", "build", "--push", "-t", config.hardlinkBaseImage, "-f", dockerfilesPath + "/Dockerfile_hardlink_base", "."},
+		command: []string{"docker", "build", coverArg, "--push", "-t", config.hardlinkBaseImage, "-f", dockerfilesPath + "/Dockerfile_hardlink_base", "."},
 	}, {
 		name:    "Building kaniko image with moved kaniko dir",
-		command: []string{"docker", "build", "-t", ExecutorImageMoved, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz444", "--target", "kaniko", "."},
+		command: []string{"docker", "build", coverArg, "-t", ExecutorImageMoved, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz444", "--target", "kaniko", "."},
 	}, {
 		name:    "Building kaniko image with leftover stuff in the filesystem",
-		command: []string{"docker", "build", "-t", ExecutorImageTainted, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz455", "--target", "kaniko", "."},
+		command: []string{"docker", "build", coverArg, "-t", ExecutorImageTainted, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz455", "--target", "kaniko", "."},
 	}, {
 		name:    "Building hijack base image",
-		command: []string{"docker", "build", "--push", "-t", config.hijackBaseImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz560", "--target", "base", "."},
+		command: []string{"docker", "build", coverArg, "--push", "-t", config.hijackBaseImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz560", "--target", "base", "."},
 	}, {
 		name:    "Building kaniko image based on alpine",
-		command: []string{"docker", "build", "-t", AlpineImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-alpine", ".."},
+		command: []string{"docker", "build", coverArg, "-t", AlpineImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-alpine", ".."},
 	}}
 
 	for _, setupCmd := range setupCommands {
@@ -315,7 +314,7 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 	kanikoImage := GetKanikoImage(config.imageRepo, imageName)
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -386,7 +385,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_git_subpath")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(
 		dockerRunFlags,
 		ExecutorImage,
@@ -430,7 +429,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_mirror")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -472,7 +471,7 @@ func TestBuildViaRegistryMap(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_map")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -499,7 +498,7 @@ func TestBuildSkipFallback(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_skip_fallback")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -540,7 +539,7 @@ func TestKanikoDir(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_kaniko_dir")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -584,7 +583,7 @@ func TestBuildWithLabels(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_label")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -625,7 +624,7 @@ func TestBuildWithHTTPError(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_add_404")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -981,7 +980,7 @@ func TestExitCodePropagation(t *testing.T) {
 			"-v", contextVolume,
 		}
 		dockerFlags = addServiceAccountFlags(dockerFlags, "")
-		dockerFlags = addCoverageFlags(dockerFlags, ExecutorImage)
+		dockerFlags = addCoverageFlags(dockerFlags)
 		dockerFlags = append(dockerFlags, ExecutorImage,
 			"-c", "dir:///workspace/",
 			"-f", "./Dockerfile_exit_code_propagation",
@@ -1034,7 +1033,7 @@ func TestBuildWithAnnotations(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_annotation")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -139,10 +139,11 @@ func buildRequiredImages() error {
 		}
 	}
 
-	kanikoImageBuildCmd := []string{"docker", "build", "-t", ExecutorImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-executor", ".."}
+	kanikoImageBuildCmd := []string{"docker", "build", "-t", ExecutorImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-executor"}
 	if coverageDir != "" {
-		kanikoImageBuildCmd = []string{"docker", "build", "-t", ExecutorImage, "--build-arg", "COVER=1", "-f", "../deploy/Dockerfile", "--target", "kaniko-executor", ".."}
+		kanikoImageBuildCmd = append(kanikoImageBuildCmd, "--build-arg", "COVER=1")
 	}
+	kanikoImageBuildCmd = append(kanikoImageBuildCmd, "..")
 
 	setupCommands := []struct {
 		name    string

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -133,12 +133,22 @@ func TestMain(m *testing.M) {
 }
 
 func buildRequiredImages() error {
+	kanikoImageTarget := "kaniko-executor"
+	kanikoImageTag := ExecutorImage
+	if coverageDir != "" {
+		kanikoImageTarget = "kaniko-executor-coverage"
+		kanikoImageTag = ExecutorImageCoverage
+		if err := os.MkdirAll(coverageDir, 0o777); err != nil {
+			return fmt.Errorf("failed to create coverage dir %s: %w", coverageDir, err)
+		}
+	}
+
 	setupCommands := []struct {
 		name    string
 		command []string
 	}{{
 		name:    "Building kaniko image",
-		command: []string{"docker", "build", "-t", ExecutorImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-executor", ".."},
+		command: []string{"docker", "build", "-t", kanikoImageTag, "-f", "../deploy/Dockerfile", "--target", kanikoImageTarget, ".."},
 	}, {
 		name:    "Building cache warmer image",
 		command: []string{"docker", "build", "-t", WarmerImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-warmer", ".."},
@@ -303,7 +313,8 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 	kanikoImage := GetKanikoImage(config.imageRepo, imageName)
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"-c", KanikoGitRepo(url, commit, branch))
@@ -373,9 +384,10 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_git_subpath")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
 	dockerRunFlags = append(
 		dockerRunFlags,
-		ExecutorImage,
+		activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"-c", KanikoGitRepo(url, "", branch),
@@ -416,7 +428,8 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_mirror")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--registry-mirror", "doesnotexist.example.com",
@@ -457,7 +470,8 @@ func TestBuildViaRegistryMap(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_map")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--registry-map", "index.docker.io=doesnotexist.example.com",
@@ -483,7 +497,8 @@ func TestBuildSkipFallback(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_skip_fallback")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--registry-mirror", "doesnotexist.example.com",
@@ -523,7 +538,8 @@ func TestKanikoDir(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_kaniko_dir")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--kaniko-dir", "/not-kaniko",
@@ -566,7 +582,8 @@ func TestBuildWithLabels(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_label")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--label", testLabel,
@@ -606,7 +623,8 @@ func TestBuildWithHTTPError(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_add_404")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"-c", KanikoGitRepo(url, "", branch),
@@ -961,7 +979,8 @@ func TestExitCodePropagation(t *testing.T) {
 			"-v", contextVolume,
 		}
 		dockerFlags = addServiceAccountFlags(dockerFlags, "")
-		dockerFlags = append(dockerFlags, ExecutorImage,
+		dockerFlags = addCoverageFlags(dockerFlags)
+		dockerFlags = append(dockerFlags, activeExecutorImage(),
 			"-c", "dir:///workspace/",
 			"-f", "./Dockerfile_exit_code_propagation",
 			"--no-push",
@@ -1013,7 +1032,8 @@ func TestBuildWithAnnotations(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_annotation")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
+	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = append(dockerRunFlags, activeExecutorImage(),
 		"-f", dockerfile,
 		"-d", kanikoImage,
 		"--annotation", fmt.Sprintf("%s=%s", annotationKey, annotationValue),
@@ -1164,6 +1184,7 @@ func initIntegrationTestConfig() *integrationTestConfig {
 	flag.BoolVar(&disableGcsAuth, "disable-gcs-auth", false, "Disable GCS Authentication. Used for local integration tests")
 	// adds the possibility to run a single dockerfile. This is useful since running all images can exhaust the dockerhub pull limit
 	flag.StringVar(&c.dockerfilesPattern, "dockerfiles-pattern", "Dockerfile_test*", "The pattern to match dockerfiles with")
+	flag.StringVar(&coverageDir, "coverage-dir", "", "Collect executor coverage data into this directory.")
 	flag.Parse()
 
 	if len(c.serviceAccount) > 0 {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -315,7 +315,7 @@ func testGitBuildcontextHelper(t *testing.T, url string, commit string, branch s
 	kanikoImage := GetKanikoImage(config.imageRepo, imageName)
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -386,7 +386,7 @@ func TestGitBuildcontextSubPath(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_git_subpath")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(
 		dockerRunFlags,
 		ExecutorImage,
@@ -430,7 +430,7 @@ func TestBuildViaRegistryMirrors(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_mirror")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -472,7 +472,7 @@ func TestBuildViaRegistryMap(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_map")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -499,7 +499,7 @@ func TestBuildSkipFallback(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_registry_skip_fallback")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -540,7 +540,7 @@ func TestKanikoDir(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_kaniko_dir")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -584,7 +584,7 @@ func TestBuildWithLabels(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_label")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -625,7 +625,7 @@ func TestBuildWithHTTPError(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_add_404")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,
@@ -981,7 +981,7 @@ func TestExitCodePropagation(t *testing.T) {
 			"-v", contextVolume,
 		}
 		dockerFlags = addServiceAccountFlags(dockerFlags, "")
-		dockerFlags = addCoverageFlags(dockerFlags)
+		dockerFlags = addCoverageFlags(dockerFlags, ExecutorImage)
 		dockerFlags = append(dockerFlags, ExecutorImage,
 			"-c", "dir:///workspace/",
 			"-f", "./Dockerfile_exit_code_propagation",
@@ -1034,7 +1034,7 @@ func TestBuildWithAnnotations(t *testing.T) {
 	kanikoImage := GetKanikoImage(config.imageRepo, "Dockerfile_test_annotation")
 	dockerRunFlags := []string{"run", "--net=host"}
 	dockerRunFlags = addServiceAccountFlags(dockerRunFlags, config.serviceAccount)
-	dockerRunFlags = addCoverageFlags(dockerRunFlags)
+	dockerRunFlags = addCoverageFlags(dockerRunFlags, ExecutorImage)
 	dockerRunFlags = append(dockerRunFlags, ExecutorImage,
 		"-f", dockerfile,
 		"-d", kanikoImage,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -155,13 +155,13 @@ func buildRequiredImages() error {
 		command: []string{"docker", "build", coverArg, "-t", WarmerImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-warmer", ".."},
 	}, {
 		name:    "Building onbuild base image",
-		command: []string{"docker", "build", coverArg, "--push", "-t", config.onbuildBaseImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_base", "."},
+		command: []string{"docker", "build", "--push", "-t", config.onbuildBaseImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_base", "."},
 	}, {
 		name:    "Building onbuild copy image",
-		command: []string{"docker", "build", coverArg, "--push", "-t", config.onbuildCopyImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_copy", "."},
+		command: []string{"docker", "build", "--push", "-t", config.onbuildCopyImage, "-f", dockerfilesPath + "/Dockerfile_onbuild_copy", "."},
 	}, {
 		name:    "Building hardlink base image",
-		command: []string{"docker", "build", coverArg, "--push", "-t", config.hardlinkBaseImage, "-f", dockerfilesPath + "/Dockerfile_hardlink_base", "."},
+		command: []string{"docker", "build", "--push", "-t", config.hardlinkBaseImage, "-f", dockerfilesPath + "/Dockerfile_hardlink_base", "."},
 	}, {
 		name:    "Building kaniko image with moved kaniko dir",
 		command: []string{"docker", "build", coverArg, "-t", ExecutorImageMoved, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz444", "--target", "kaniko", "."},
@@ -170,7 +170,7 @@ func buildRequiredImages() error {
 		command: []string{"docker", "build", coverArg, "-t", ExecutorImageTainted, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz455", "--target", "kaniko", "."},
 	}, {
 		name:    "Building hijack base image",
-		command: []string{"docker", "build", coverArg, "--push", "-t", config.hijackBaseImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz560", "--target", "base", "."},
+		command: []string{"docker", "build", "--push", "-t", config.hijackBaseImage, "-f", dockerfilesPath + "/Dockerfile_test_issue_mz560", "--target", "base", "."},
 	}, {
 		name:    "Building kaniko image based on alpine",
 		command: []string{"docker", "build", coverArg, "-t", AlpineImage, "-f", "../deploy/Dockerfile", "--target", "kaniko-alpine", ".."},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -139,7 +139,7 @@ func buildRequiredImages() error {
 		}
 	}
 
-	coverArg := "--build-arg=COVER=0"
+	coverArg := "--build-arg=COVER="
 	if coverageDir != "" {
 		coverArg = "--build-arg=COVER=1"
 	}

--- a/integration/k8s-job.yaml
+++ b/integration/k8s-job.yaml
@@ -17,12 +17,25 @@ spec:
           value: "1"
         - name: FF_KANIKO_RUN_MOUNT_BIND
           value: "1"
+        {{- if .CoverageDir}}
+        - name: GOCOVERDIR
+          value: /covdata
+        {{- end}}
         volumeMounts:
         - name: context
           mountPath: /workspace
+        {{- if .CoverageDir}}
+        - name: covdata
+          mountPath: /covdata
+        {{- end}}
       restartPolicy: Never
       volumes:
       - name: context
         hostPath:
           path: {{.Context}}
+      {{- if .CoverageDir}}
+      - name: covdata
+        hostPath:
+          path: {{.CoverageDir}}
+      {{- end}}
   backoffLimit: 1

--- a/integration/k8s_test.go
+++ b/integration/k8s_test.go
@@ -30,6 +30,7 @@ type K8sConfig struct {
 	KanikoImage string
 	Context     string
 	Name        string
+	CoverageDir string
 }
 
 func TestK8s(t *testing.T) {
@@ -78,7 +79,7 @@ func TestK8s(t *testing.T) {
 			}
 			defer os.Remove(tmpfile.Name()) // clean up
 			tmpl := template.Must(template.ParseFiles("k8s-job.yaml"))
-			job := K8sConfig{KanikoImage: kanikoImage, Context: testDir, Name: name}
+			job := K8sConfig{KanikoImage: kanikoImage, Context: testDir, Name: name, CoverageDir: coverageDir}
 			if err := tmpl.Execute(tmpfile, job); err != nil {
 				t.Fatal(err)
 			}

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -62,9 +62,6 @@ fi
 go test ./integration/... "${FLAGS[@]}" "$@"
 
 if [[ -n ${COVERAGE_DIR} ]]; then
-  # Coverage files are written as root by the container; fix ownership so the
-  # calling user can read and process them.
-  sudo chown -R "$(id -u):$(id -g)" "${COVERAGE_DIR}" 2>/dev/null || true
   merged="${COVERAGE_DIR}-merged"
   mkdir -p "${merged}"
   go tool covdata merge -i "${COVERAGE_DIR}" -o "${merged}"

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -61,10 +61,3 @@ fi
 
 go test ./integration/... "${FLAGS[@]}" "$@"
 
-if [[ -n ${COVERAGE_DIR} ]]; then
-  merged="${COVERAGE_DIR}-merged"
-  mkdir -p "${merged}"
-  go tool covdata merge -i "${COVERAGE_DIR}" -o "${merged}"
-  go tool covdata textfmt -i "${merged}" -o "${COVERAGE_DIR}/coverage.txt"
-  echo "Integration coverage written to ${COVERAGE_DIR}/coverage.txt"
-fi

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -55,4 +55,19 @@ FLAGS+=(
   "--repo=${IMAGE_REPO}"
 )
 
+if [[ -n ${COVERAGE_DIR} ]]; then
+  FLAGS+=("--coverage-dir=${COVERAGE_DIR}")
+fi
+
 go test ./integration/... "${FLAGS[@]}" "$@"
+
+if [[ -n ${COVERAGE_DIR} ]]; then
+  # Coverage files are written as root by the container; fix ownership so the
+  # calling user can read and process them.
+  sudo chown -R "$(id -u):$(id -g)" "${COVERAGE_DIR}" 2>/dev/null || true
+  merged="${COVERAGE_DIR}-merged"
+  mkdir -p "${merged}"
+  go tool covdata merge -i "${COVERAGE_DIR}" -o "${merged}"
+  go tool covdata textfmt -i "${merged}" -o "${COVERAGE_DIR}/coverage.txt"
+  echo "Integration coverage written to ${COVERAGE_DIR}/coverage.txt"
+fi


### PR DESCRIPTION
## Description

Wires up Go's built-in coverage instrumentation (`-cover`) to the integration test suite so we can see which executor code paths are actually exercised during integration tests.

## How it works

- `COVER` build arg (passed to `docker build`) controls whether the executor and warmer binaries are compiled with `-cover`. Defaults to off, so production builds are unaffected.
- When `--coverage-dir <dir>` is passed to the integration test binary, every `docker run` invocation of the executor gets `-v <dir>:/covdata -e GOCOVERDIR=/covdata` injected, so the instrumented binary writes coverage data on exit.
- The CI workflow sets `COVERAGE_DIR` from the workspace and passes it through `scripts/integration-test.sh` → `--coverage-dir` flag.
- Each parallel matrix job uploads its `out/covdata/` as a separate artifact.
- A new `coverage-merge` job runs after all matrix jobs finish, merges the per-job coverage profiles with `go tool covdata merge`, converts to text format, and publishes a combined HTML report as an artifact.

## What's not changed

- No change to executor behavior or output images.
- Coverage mode is strictly opt-in via `COVER=1` / `--coverage-dir`; regular local builds and runs are unaffected.
- The `checkout` and `setup-go` step order in the CI workflow was swapped to match the rest of our jobs (no functional impact).

## Release Notes

None — CI infrastructure only.