### PR TITLE
mz661: resolve secrets before moving kaniko dir

### DIFF
--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -126,6 +126,12 @@ var RootCmd = &cobra.Command{
 
 			ValidateFlags(opts)
 
+			// mz661: resolveSecrets must run before moveKanikoDir so that secret src=
+			// paths pointing into the original kaniko dir are still valid when copied.
+			if err := resolveSecrets(); err != nil {
+				return fmt.Errorf("error resolving secrets: %w", err)
+			}
+
 			// Command line flag takes precedence over the KANIKO_DIR environment variable.
 			dir := config.KanikoDir
 			if opts.KanikoDir != "" {
@@ -152,9 +158,6 @@ var RootCmd = &cobra.Command{
 			}
 			if err := resolveDockerfilePath(); err != nil {
 				return fmt.Errorf("error resolving dockerfile path: %w", err)
-			}
-			if err := resolveSecrets(); err != nil {
-				return fmt.Errorf("error resolving secrets: %w", err)
 			}
 			if len(opts.Destinations) == 0 && opts.ImageNameDigestFile != "" {
 				return errors.New("you must provide --destination if setting ImageNameDigestFile")
@@ -445,16 +448,19 @@ func resolveSecrets() error {
 			// In multistage builds the original secret file might be deleted between stages.
 			// We therefore safeguard it across stages by copying it into /kaniko.
 			// We are not allowed to move it as it might be mounted into the container.
-			destPath := filepath.Join(config.KanikoSecretsDir, k)
-			err := os.MkdirAll(config.KanikoSecretsDir, 0o700)
+			// mz661: copy into KanikoExeDir so moveKanikoDir carries the file to
+			// KanikoSecretsDir automatically. s.Src is set to the post-move path.
+			destPathBefore := filepath.Join(config.KanikoSecretsBeforeDir, k)
+			destPathAfter := filepath.Join(config.KanikoSecretsDir, k)
+			err := os.MkdirAll(config.KanikoSecretsBeforeDir, 0o700)
 			if err != nil {
 				return err
 			}
-			err = util.CopyFileInternal(s.Src, destPath, util.FileContext{})
+			err = util.CopyFileInternal(s.Src, destPathBefore, util.FileContext{})
 			if err != nil {
 				return fmt.Errorf("copying secret %s: %w", s.Src, err)
 			}
-			s.Src = destPath
+			s.Src = destPathAfter
 			// mz511: we need to write back to the dict to persist the update
 			opts.Secrets[k] = s
 		}

--- a/integration/dockerfiles/Dockerfile_test_issue_mz661
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz661
@@ -1,0 +1,10 @@
+# mz661: in kaniko v1.27.3, when running with KANIKO_DIR=/kaniko2 to relocate the
+# executor, moveKanikoDir runs before resolveSecrets. A --secret with src= pointing
+# into the original kaniko dir (e.g. src=/kaniko/.netrc) is moved away before the
+# secret is resolved, causing "open /kaniko/.netrc: no such file or directory".
+
+# /kaniko/executor is used as the secret source here only because it is a file that
+# already exists in the container, standing in for any real credential file.
+# Verify here that the secret is accessible inside the build.
+FROM busybox
+RUN echo blubb

--- a/integration/dockerfiles/Dockerfile_test_issue_mz661
+++ b/integration/dockerfiles/Dockerfile_test_issue_mz661
@@ -7,4 +7,4 @@
 # already exists in the container, standing in for any real credential file.
 # Verify here that the secret is accessible inside the build.
 FROM busybox
-RUN echo blubb
+RUN --mount=type=secret,id=kaniko test -s /run/secrets/kaniko

--- a/integration/images.go
+++ b/integration/images.go
@@ -95,6 +95,7 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_mz473":                {"KANIKO_DIR=/kaniko2"},
 	"Dockerfile_test_issue_mz511":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz529":                {"FF_KANIKO_SQUASH_STAGES=0"},
+	"Dockerfile_test_issue_mz661":                {"KANIKO_DIR=/kaniko2"},
 }
 
 var KanikoEnv = []string{
@@ -190,6 +191,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	// in the kaniko image and can therefore safely be deleted.
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=/etc/nsswitch.conf"},
 	"Dockerfile_test_issue_mz529": {"--cleanup"},
+	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=/kaniko/executor"},
 }
 
 var expectErr = map[string]int{

--- a/integration/images.go
+++ b/integration/images.go
@@ -121,6 +121,7 @@ var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_target":      {"--target=second"},
 	"Dockerfile_test_issue_cg188": {"--secret=id=netrc,env=SECRET"},
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=context/foo"},
+	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=context/foo"},
 	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
 	"Dockerfile_test_mv_add":                       {"--provenance=false"},
 	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},

--- a/pkg/config/init.go
+++ b/pkg/config/init.go
@@ -80,6 +80,8 @@ var KanikoSwapDir = KanikoDir + "/swap/"
 var DockerConfigDir = KanikoDir + "/.docker/"
 
 // KanikoSecretsDir is a where user defined secrets are stored
+// KanikoSecretsBeforeDir is where secrets are staged before moveKanikoDir runs
+var KanikoSecretsBeforeDir = KanikoExeDir + "/secrets/"
 var KanikoSecretsDir = KanikoDir + "/secrets/"
 
 var TiniExec = KanikoDir + "/tini"


### PR DESCRIPTION
## Summary

Fixes #661.

When `KANIKO_DIR` points to a path other than the executor directory, `moveKanikoDir` relocated all files under the original kaniko dir before `resolveSecrets` ran. Any `--secret` with `src=` pointing into that dir (e.g. `src=/kaniko/.netrc`) was therefore gone by the time its path was read, causing the build to fail with `open /kaniko/.netrc: no such file or directory`.

The fix moves `resolveSecrets` before `moveKanikoDir`. To avoid creating the target dir prematurely (which would break the rename), secrets are staged under `KanikoExeDir` first; `moveKanikoDir` then carries them to their final location under `KanikoDir` automatically.

## Test plan

- [ ] `LOCAL=1 DOCKERFILE_PATTERN=Dockerfile_test_issue_mz661 make integration-test-run` passes
- [ ] Existing integration tests unaffected