### PR TITLE
mz640: warn when a COPY is silently skipped due to the ignore list

### DIFF
--- a/integration/images.go
+++ b/integration/images.go
@@ -283,36 +283,28 @@ var warmerOutputChecks = map[string]func(string, []byte) error{
 	},
 }
 
-// expectedWarnings maps a Dockerfile name to warning substrings that must appear in its output.
-// Dockerfiles listed here are required to emit those warnings; all others must emit no warnings.
-var expectedWarnings = map[string][]string{
+// expectedWarnings maps a Dockerfile name to a warning substring that must appear in its output.
+// Dockerfiles listed here are required to emit that warning; all others must emit no warnings.
+var expectedWarnings = map[string]string{
 	// mz640: COPY to /kaniko (ignored path) must warn rather than silently skip.
-	"Dockerfile_test_issue_mz560": {"Skipping copy for ignored path"},
+	"Dockerfile_test_issue_mz560": "Skipping copy for ignored path",
 }
 
 func checkNoWarnings(dockerfile string, out []byte) error {
-	expected := expectedWarnings[dockerfile]
-	found := make([]bool, len(expected))
+	expected, hasExpected := expectedWarnings[dockerfile]
+	found := false
 	for line := range strings.SplitSeq(string(out), "\n") {
 		if !strings.Contains(line, "WARN") {
 			continue
 		}
-		covered := false
-		for i, w := range expected {
-			if strings.Contains(line, w) {
-				found[i] = true
-				covered = true
-				break
-			}
+		if hasExpected && strings.Contains(line, expected) {
+			found = true
+			continue
 		}
-		if !covered {
-			return fmt.Errorf("unexpected WARN in output: %s", line)
-		}
+		return fmt.Errorf("unexpected WARN in output: %s", line)
 	}
-	for i, w := range expected {
-		if !found[i] {
-			return fmt.Errorf("expected WARN %q not found in output", w)
-		}
+	if hasExpected && !found {
+		return fmt.Errorf("expected WARN %q not found in output", expected)
 	}
 	return nil
 }

--- a/integration/images.go
+++ b/integration/images.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -284,9 +283,36 @@ var warmerOutputChecks = map[string]func(string, []byte) error{
 	},
 }
 
-func checkNoWarnings(_ string, out []byte) error {
-	if strings.Contains(string(out), "WARN") {
-		return errors.New("output must not contain WARN")
+// expectedWarnings maps a Dockerfile name to warning substrings that must appear in its output.
+// Dockerfiles listed here are required to emit those warnings; all others must emit no warnings.
+var expectedWarnings = map[string][]string{
+	// mz640: COPY to /kaniko (ignored path) must warn rather than silently skip.
+	"Dockerfile_test_issue_mz560": {"Skipping copy for ignored path"},
+}
+
+func checkNoWarnings(dockerfile string, out []byte) error {
+	expected := expectedWarnings[dockerfile]
+	found := make([]bool, len(expected))
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if !strings.Contains(line, "WARN") {
+			continue
+		}
+		covered := false
+		for i, w := range expected {
+			if strings.Contains(line, w) {
+				found[i] = true
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			return fmt.Errorf("unexpected WARN in output: %s", line)
+		}
+	}
+	for i, w := range expected {
+		if !found[i] {
+			return fmt.Errorf("expected WARN %q not found in output", w)
+		}
 	}
 	return nil
 }

--- a/integration/images.go
+++ b/integration/images.go
@@ -287,7 +287,7 @@ var warmerOutputChecks = map[string]func(string, []byte) error{
 // Dockerfiles listed here are required to emit that warning; all others must emit no warnings.
 var expectedWarnings = map[string]string{
 	// mz640: COPY to /kaniko (ignored path) must warn rather than silently skip.
-	"Dockerfile_test_issue_mz560": "Skipping copy for ignored path",
+	"Dockerfile_test_issue_mz560": "Skipping copy targeting kaniko directory",
 }
 
 func checkNoWarnings(dockerfile string, out []byte) error {

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -150,8 +150,8 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		if err != nil {
 			return fmt.Errorf("find destination path: %w", err)
 		}
-		if util.CheckIgnoreList(destPath) {
-			logrus.Warnf("Skipping copy for ignored path: %s", destPath)
+		if util.HasFilepathPrefix(destPath, kConfig.KanikoDir, false) {
+			logrus.Warnf("Skipping copy targeting kaniko directory: %s", destPath)
 			return nil
 		}
 

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -151,7 +151,7 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 			return fmt.Errorf("find destination path: %w", err)
 		}
 		if util.CheckIgnoreList(destPath) {
-			logrus.Debugf("Skipping copy for ignored path: %s", destPath)
+			logrus.Warnf("Skipping copy for ignored path: %s", destPath)
 			return nil
 		}
 

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -152,6 +152,8 @@ func (c *CopyCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfile.Bu
 		}
 		if util.HasFilepathPrefix(destPath, kConfig.KanikoDir, false) {
 			logrus.Warnf("Skipping copy targeting kaniko directory: %s", destPath)
+			logrus.Info("Writes to the kaniko directory are blocked to prevent overwriting the executor.")
+			logrus.Info("To copy files there, relocate kaniko with KANIKO_DIR: https://github.com/osscontainertools/kaniko#bootstrapping-kaniko")
 			return nil
 		}
 

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -823,8 +823,8 @@ func CopySymlink(src, dest string, context FileContext) (bool, error) {
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
 	}
-	if CheckIgnoreList(dest) {
-		logrus.Warnf("Skipping copy for ignored path: %s", dest)
+	if HasFilepathPrefix(dest, config.KanikoDir, false) {
+		logrus.Warnf("Skipping copy targeting kaniko directory: %s", dest)
 		return true, nil
 	}
 	if FilepathExists(dest) {
@@ -848,8 +848,8 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod fs.Fi
 		logrus.Debugf("%s found in .dockerignore, ignoring", src)
 		return true, nil
 	}
-	if CheckIgnoreList(dest) {
-		logrus.Warnf("Skipping copy for ignored path: %s", dest)
+	if HasFilepathPrefix(dest, config.KanikoDir, false) {
+		logrus.Warnf("Skipping copy targeting kaniko directory: %s", dest)
 		return true, nil
 	}
 	if src == dest {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -824,7 +824,7 @@ func CopySymlink(src, dest string, context FileContext) (bool, error) {
 		return true, nil
 	}
 	if CheckIgnoreList(dest) {
-		logrus.Debugf("Skipping copy for ignored path: %s", dest)
+		logrus.Warnf("Skipping copy for ignored path: %s", dest)
 		return true, nil
 	}
 	if FilepathExists(dest) {
@@ -849,7 +849,7 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod fs.Fi
 		return true, nil
 	}
 	if CheckIgnoreList(dest) {
-		logrus.Debugf("Skipping copy for ignored path: %s", dest)
+		logrus.Warnf("Skipping copy for ignored path: %s", dest)
 		return true, nil
 	}
 	if src == dest {

--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -825,6 +825,8 @@ func CopySymlink(src, dest string, context FileContext) (bool, error) {
 	}
 	if HasFilepathPrefix(dest, config.KanikoDir, false) {
 		logrus.Warnf("Skipping copy targeting kaniko directory: %s", dest)
+		logrus.Info("Writes to the kaniko directory are blocked to prevent overwriting the executor.")
+		logrus.Info("To copy files there, relocate kaniko with KANIKO_DIR: https://github.com/osscontainertools/kaniko#bootstrapping-kaniko")
 		return true, nil
 	}
 	if FilepathExists(dest) {
@@ -850,6 +852,8 @@ func CopyFile(src, dest string, context FileContext, uid, gid int64, chmod fs.Fi
 	}
 	if HasFilepathPrefix(dest, config.KanikoDir, false) {
 		logrus.Warnf("Skipping copy targeting kaniko directory: %s", dest)
+		logrus.Info("Writes to the kaniko directory are blocked to prevent overwriting the executor.")
+		logrus.Info("To copy files there, relocate kaniko with KANIKO_DIR: https://github.com/osscontainertools/kaniko#bootstrapping-kaniko")
 		return true, nil
 	}
 	if src == dest {


### PR DESCRIPTION
## Summary

Fixes #640 #652 

mz587 added ignore-list checks to prevent hijacking files under `/kaniko`. Those checks logged at `debug` level, so users whose builds relied on overwriting paths like `/kaniko/ssl/certs/ca-certificates.crt` saw a silent no-op with no indication of why the `COPY` had no effect.

Escalate the three call sites from `Debugf` to `Warnf` so the skip is visible at the default log level.