### PR TITLE
mz595: harden CI

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -32,7 +32,7 @@ jobs:
       id-token: write # Produce identity token for keyless signing.
       packages: write # push to ghcr registry
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -127,7 +127,7 @@ jobs:
         run: echo "now=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - if: steps.context.outputs.should_push == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -192,7 +192,7 @@ jobs:
 
       # If a tag push, distribute to other registries too
       - if: steps.context.outputs.is_release == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -87,7 +87,20 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
+        with:
+          remove-android: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+          remove-large-packages: 'true'
+          remove-cached-tools: 'true'
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Define build context
         id: context

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -42,7 +42,6 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
-          check-latest: true
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,11 +32,6 @@ jobs:
           - k8s-executor-build-push integration-test-k8s
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
-
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
         with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,12 +32,21 @@ jobs:
           - k8s-executor-build-push integration-test-k8s
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Maximize build space
         uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
         with:
           remove-android: 'true'
           remove-dotnet: 'true'
           remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+          remove-large-packages: 'true'
+          remove-cached-tools: 'true'
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/nightly-vulnerability-scan.yml
+++ b/.github/workflows/nightly-vulnerability-scan.yml
@@ -12,7 +12,7 @@ jobs:
       packages: read # pull image from ghcr registry
       issues: write # create issues via gh CLI
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Harden Runner
@@ -25,9 +25,14 @@ jobs:
           persist-credentials: false
 
       - name: Set up Grype
+        env:
+          GRYPE_VERSION: "0.111.1"
+          GRYPE_SHA256: "2bc0bc60f1f4e10b0429f5e84517ec4cf0d769d2ef66875c64fc6640e136fd8f"
         run: |
-          # Install Grype
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+          curl -sSfL "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz" -o grype.tar.gz
+          echo "${GRYPE_SHA256}  grype.tar.gz" | sha256sum -c
+          tar -xzf grype.tar.gz grype
+          sudo mv grype /usr/local/bin/grype
 
       - name: Get latest commit SHA of Kaniko project
         id: get-commit

--- a/.github/workflows/nightly-vulnerability-scan.yml
+++ b/.github/workflows/nightly-vulnerability-scan.yml
@@ -5,6 +5,8 @@ on:
     # Schedule to run every night at midnight
     - cron: '0 0 * * *'
 
+permissions: {}
+
 jobs:
   vulnerability-scan:
 
@@ -19,6 +21,18 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
+
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
+        with:
+          remove-android: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+          remove-large-packages: 'true'
+          remove-cached-tools: 'true'
+          remove-swapfile: 'true'
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -39,7 +53,7 @@ jobs:
         run: |
           LATEST_COMMIT_SHA=$(git rev-parse HEAD)
           echo "Latest commit SHA: $LATEST_COMMIT_SHA"
-          echo "::set-output name=sha::$LATEST_COMMIT_SHA"
+          echo "sha=$LATEST_COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Scan the latest CI/CD image
         run: |

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -30,14 +30,13 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.2'
-          check-latest: true
 
       - run: make test
 
       - run: make golden
 
       - name: Run staticcheck
-        uses: dominikh/staticcheck-action@v1.4.1
+        uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
           install-go: false
-          version: 'latest'
+          version: '2026.1'

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,6 +23,17 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Maximize build space
+        uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
+        with:
+          remove-android: 'true'
+          remove-dotnet: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+          remove-large-packages: 'true'
+          remove-cached-tools: 'true'
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -52,7 +52,7 @@ RUN make COVER="$COVER" out/executor out/warmer \
 
 # Generate latest ca-certificates
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS certs
+FROM --platform=$BUILDPLATFORM debian:trixie-slim@sha256:e18da95f66066b7c5fa31491b524e83121271eca59a3d140f4906c8d0a090367 AS certs
 RUN apt update && apt install -y ca-certificates
 
 # use musl busybox since it's staticly compiled on all platforms

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -84,16 +84,26 @@ ENV DOCKER_CREDENTIAL_GCR_CONFIG=/kaniko/.config/gcloud/docker_credential_gcr_co
 WORKDIR /workspace
 
 # mz446: there is no tini binary release on riscv64
-FROM kaniko-base AS kaniko-base-tini
-ARG TARGETARCH
-ARG TINI_VERSION=v0.19.0
-ADD --chmod=555 \
-    https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${TARGETARCH} \
+FROM kaniko-base AS kaniko-base-amd64
+ADD --checksum=sha256:c5b0666b4cb676901f90dfcb37106783c5fe2077b04590973b885950611b30ee \
+    --chown=0:0 --chmod=555 \
+    https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-amd64 \
     /kaniko/tini
-FROM kaniko-base-tini AS kaniko-base-amd64
-FROM kaniko-base-tini AS kaniko-base-arm64
-FROM kaniko-base-tini AS kaniko-base-s390x
-FROM kaniko-base-tini AS kaniko-base-ppc64le
+FROM kaniko-base AS kaniko-base-arm64
+ADD --checksum=sha256:eae1d3aa50c48fb23b8cbdf4e369d0910dfc538566bfd09df89a774aa84a48b9 \
+    --chown=0:0 --chmod=555 \
+    https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-arm64 \
+    /kaniko/tini
+FROM kaniko-base AS kaniko-base-s390x
+ADD --checksum=sha256:95657aec2459ff06123e0674565da625c50704b1db86373cd91afc3c0dcce997 \
+    --chown=0:0 --chmod=555 \
+    https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-s390x \
+    /kaniko/tini
+FROM kaniko-base AS kaniko-base-ppc64le
+ADD --checksum=sha256:b913a6d5be168a14cfe5f27238a181a12aece281e30a57e5d31a148bc5dfb687 \
+    --chown=0:0 --chmod=555 \
+    https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-ppc64le \
+    /kaniko/tini
 FROM kaniko-base AS kaniko-base-riscv64
 FROM kaniko-base-${TARGETARCH} AS kaniko-base-2
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2@sha256:5f3787b7f902c07c7ec4f3aa91a301a3eda8133aa32661a3b3a3a86ab3a68a36 AS builder
 WORKDIR /src
 
 # This arg is passed by docker buildx & contains the target CPU architecture (e.g., amd64, arm64, etc.)
@@ -52,11 +52,11 @@ RUN make COVER="$COVER" out/executor out/warmer \
 
 # Generate latest ca-certificates
 ARG BUILDPLATFORM
-FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS certs
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS certs
 RUN apt update && apt install -y ca-certificates
 
 # use musl busybox since it's staticly compiled on all platforms
-FROM busybox:musl AS busybox
+FROM busybox:musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138 AS busybox
 RUN mkdir -p /kaniko && chmod 777 /kaniko
 
 FROM scratch AS kaniko-base-slim
@@ -111,7 +111,7 @@ COPY --from=builder /src/out/executor /kaniko/executor
 
 ENTRYPOINT ["/kaniko/executor"]
 
-FROM alpine AS kaniko-alpine
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS kaniko-alpine
 
 RUN apk add --no-cache ca-certificates git
 

--- a/scripts/k3s-setup.sh
+++ b/scripts/k3s-setup.sh
@@ -20,7 +20,7 @@ export INSTALL_K3S_EXEC="--write-kubeconfig-mode=0644"
 mkdir -p "${HOME}/.kube"
 export K3S_KUBECONFIG_OUTPUT="${HOME}/.kube/config"
 export KUBECONFIG="${HOME}/.kube/config"
-curl -sfL https://get.k3s.io | sh -
+INSTALL_K3S_VERSION="v1.35.3+k3s1" curl -sfL https://get.k3s.io | sh -
 export SCRIPT_PATH="$(realpath $(dirname $0))"
 timeout 5m bash -c 'until kubectl cluster-info 2>/dev/null | grep "CoreDNS" >/dev/null; do sleep 1; done'
 # Install local registry and have it listen on localhost:5000

--- a/scripts/k3s-setup.sh
+++ b/scripts/k3s-setup.sh
@@ -20,7 +20,7 @@ export INSTALL_K3S_EXEC="--write-kubeconfig-mode=0644"
 mkdir -p "${HOME}/.kube"
 export K3S_KUBECONFIG_OUTPUT="${HOME}/.kube/config"
 export KUBECONFIG="${HOME}/.kube/config"
-INSTALL_K3S_VERSION="v1.35.3+k3s1" curl -sfL https://get.k3s.io | sh -
+INSTALL_K3S_VERSION="v1.35.4+k3s1" curl -sfL https://get.k3s.io | sh -
 export SCRIPT_PATH="$(realpath $(dirname $0))"
 timeout 5m bash -c 'until kubectl cluster-info 2>/dev/null | grep "CoreDNS" >/dev/null; do sleep 1; done'
 # Install local registry and have it listen on localhost:5000


### PR DESCRIPTION
## Summary

Hardens the CI pipelines against supply-chain and runner environment risks.

**Pin runners** — all workflows move from `ubuntu-latest` to `ubuntu-24.04` so the runner image is stable and auditable.

**Pin actions and images to SHAs** — every `uses:` reference that was floating on a tag is now pinned to a commit SHA. Docker base images in `deploy/Dockerfile` are pinned to digest. Grype is downloaded at a specific version and its tarball is verified with a SHA-256 checksum rather than piped from a curl-to-sh install script.

**Harden runner egress** — `step-security/harden-runner` with `egress-policy: audit` is added to workflows that were missing it; `permissions: {}` is set at the top level of `nightly-vulnerability-scan.yml`.

**Strip the runner environment** — the `remove-unwanted-software` step is extended with additional removal flags (`remove-codeql`, `remove-docker-images`, `remove-large-packages`, `remove-cached-tools`) across all workflows. Fewer tools installed means fewer things that can go wrong or be exploited during a build.

**Pin k3s version** — `k3s-setup.sh` sets `INSTALL_K3S_VERSION` so integration tests do not silently pick up a new k3s release.

**Minor fixes** — remove deprecated `::set-output` in favour of `$GITHUB_OUTPUT`; drop `check-latest: true` from Go setup; pin staticcheck to `2026.1`.

## Test plan

- [ ] CI passes on this PR
- [ ] Existing integration tests unaffected