### PR TITLE
mz668: improve integration test coverage

### DIFF
--- a/integration/dockerfiles/Dockerfile_test_cross_compile
+++ b/integration/dockerfiles/Dockerfile_test_cross_compile
@@ -1,0 +1,9 @@
+FROM alpine AS base
+LABEL stage=base
+COPY context/foo /base/foo
+
+FROM base AS app
+WORKDIR /app
+COPY --from=base /base/foo /app/foo
+ENV GREETING=hello
+LABEL test=cross-compile

--- a/integration/dockerfiles/Dockerfile_test_healthcheck
+++ b/integration/dockerfiles/Dockerfile_test_healthcheck
@@ -1,0 +1,2 @@
+FROM scratch
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 CMD wget -q -O /dev/null http://localhost/ || exit 1

--- a/integration/dockerfiles/Dockerfile_test_ignore_path
+++ b/integration/dockerfiles/Dockerfile_test_ignore_path
@@ -1,0 +1,6 @@
+FROM alpine
+RUN mkdir /app && echo "normal" > /app/data.txt && \
+    if ls -l /proc/1/exe | grep -q '/kaniko/executor'; then \
+        touch /kaniko-extra-file && \
+        mkdir /kaniko-extra-dir && touch /kaniko-extra-dir/child.txt; \
+    fi

--- a/integration/dockerfiles/Dockerfile_test_ignore_path
+++ b/integration/dockerfiles/Dockerfile_test_ignore_path
@@ -1,4 +1,7 @@
 FROM alpine
+# Create extra files only under kaniko so that --ignore-path is what makes the
+# kaniko and docker output match. Docker never creates them, so without
+# --ignore-path the kaniko image would contain them and the diff would fail.
 RUN mkdir /app && echo "normal" > /app/data.txt && \
     if ls -l /proc/1/exe | grep -q '/kaniko/executor'; then \
         touch /kaniko-extra-file && \

--- a/integration/dockerfiles/Dockerfile_test_shell
+++ b/integration/dockerfiles/Dockerfile_test_shell
@@ -1,0 +1,3 @@
+FROM alpine
+SHELL ["/bin/sh", "-c"]
+RUN echo "using custom shell"

--- a/integration/dockerfiles/Dockerfile_test_stopsignal
+++ b/integration/dockerfiles/Dockerfile_test_stopsignal
@@ -1,0 +1,2 @@
+FROM scratch
+STOPSIGNAL SIGTERM

--- a/integration/images.go
+++ b/integration/images.go
@@ -105,6 +105,8 @@ var envsMap = map[string][]string{
 	"Dockerfile_test_issue_mz511":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz529":                {"FF_KANIKO_SQUASH_STAGES=0"},
 	"Dockerfile_test_issue_mz661":                {"KANIKO_DIR=/kaniko2"},
+	"Dockerfile_test_stopsignal":                 {"FF_KANIKO_OCI_SCRATCH_BASE=0"},
+	"Dockerfile_test_healthcheck":                {"FF_KANIKO_OCI_SCRATCH_BASE=0"},
 }
 
 var KanikoEnv = []string{

--- a/integration/images.go
+++ b/integration/images.go
@@ -219,7 +219,8 @@ var expectErr = map[string]int{
 
 // Platform overrides for docker pull and diffoci, keyed by test name.
 var platformMap = map[string][]string{
-	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/arm64"},
+	"TestRun/test_Dockerfile_test_cross_compile":          {"--platform=linux/arm64"},
+	"TestLayers/test_layer_Dockerfile_test_cross_compile": {"--platform=linux/arm64"},
 }
 
 // Arguments to diffoci when comparing dockerfiles

--- a/integration/images.go
+++ b/integration/images.go
@@ -136,6 +136,7 @@ var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=context/foo"},
 	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=context/foo"},
 	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
+	"Dockerfile_test_cross_compile":                {"--platform=linux/arm64"},
 	"Dockerfile_test_mv_add":                       {"--provenance=false"},
 	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},
 	"Dockerfile_test_whitelist":                    {"--provenance=false"},
@@ -204,7 +205,8 @@ var additionalKanikoFlagsMap = map[string][]string{
 	// mz511: we're using /etc/nsswitch.conf because it pre-exists
 	// in the kaniko image and can therefore safely be deleted.
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=/etc/nsswitch.conf"},
-	"Dockerfile_test_ignore_path": {"--ignore-path=/kaniko-extra-file", "--ignore-path=/kaniko-extra-dir"},
+	"Dockerfile_test_ignore_path":    {"--ignore-path=/kaniko-extra-file", "--ignore-path=/kaniko-extra-dir"},
+	"Dockerfile_test_cross_compile": {"--custom-platform=linux/arm64"},
 	"Dockerfile_test_issue_mz529": {"--cleanup"},
 	"Dockerfile_test_issue_mz595": {"--cleanup"},
 	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=/kaniko/executor"},
@@ -213,6 +215,11 @@ var additionalKanikoFlagsMap = map[string][]string{
 var expectErr = map[string]int{
 	"Dockerfile_test_issue_cg326_1": 1,
 	"Dockerfile_test_add_404":       1,
+}
+
+// Platform overrides for docker pull and diffoci, keyed by test name.
+var platformMap = map[string][]string{
+	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/arm64"},
 }
 
 // Arguments to diffoci when comparing dockerfiles
@@ -227,7 +234,8 @@ var diffArgsMap = map[string][]string{
 	// when we untar we overwrite the parent directory, buildkit doesnt
 	"TestRun/test_Dockerfile_test_add": {"--extra-ignore-file-permissions"},
 	// Verify we don't store root directory
-	"TestRun/test_Dockerfile_test_root": {"--extra-ignore-layer-length-mismatch=false"},
+	"TestRun/test_Dockerfile_test_root":           {"--extra-ignore-layer-length-mismatch=false"},
+	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/arm64"},
 	// --ignore-path must suppress the kaniko-only file; layer-length-mismatch would mask the difference
 	"TestRun/test_Dockerfile_test_ignore_path": {"--extra-ignore-layer-length-mismatch=false"},
 	// FROM scratch we start with root, buildkit doesnt

--- a/integration/images.go
+++ b/integration/images.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/osscontainertools/kaniko/pkg/timing"
 	"github.com/osscontainertools/kaniko/pkg/util"
 	"github.com/osscontainertools/kaniko/pkg/util/bucket"
@@ -218,9 +219,9 @@ var expectErr = map[string]int{
 }
 
 // Platform overrides for docker pull and diffoci, keyed by test name.
-var platformMap = map[string][]string{
-	"TestRun/test_Dockerfile_test_cross_compile":          {"--platform=linux/arm64"},
-	"TestLayers/test_layer_Dockerfile_test_cross_compile": {"--platform=linux/arm64"},
+var platformMap = map[string]v1.Platform{
+	"TestRun/test_Dockerfile_test_cross_compile":          {OS: "linux", Architecture: "arm64"},
+	"TestLayers/test_layer_Dockerfile_test_cross_compile": {OS: "linux", Architecture: "arm64"},
 }
 
 // Arguments to diffoci when comparing dockerfiles

--- a/integration/images.go
+++ b/integration/images.go
@@ -137,7 +137,7 @@ var additionalDockerFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=context/foo"},
 	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=context/foo"},
 	// provenance forces ociv1 on buildkit but for these images we emit dockerv2 in kaniko
-	"Dockerfile_test_cross_compile":                {"--platform=linux/arm64"},
+	"Dockerfile_test_cross_compile":                {"--platform=linux/" + crossCompileArch},
 	"Dockerfile_test_mv_add":                       {"--provenance=false"},
 	"Dockerfile_test_snapshotter_ignorelist":       {"--provenance=false"},
 	"Dockerfile_test_whitelist":                    {"--provenance=false"},
@@ -207,7 +207,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	// in the kaniko image and can therefore safely be deleted.
 	"Dockerfile_test_issue_mz511":   {"--secret=id=netrc,src=/etc/nsswitch.conf"},
 	"Dockerfile_test_ignore_path":   {"--ignore-path=/kaniko-extra-file", "--ignore-path=/kaniko-extra-dir"},
-	"Dockerfile_test_cross_compile": {"--custom-platform=linux/arm64"},
+	"Dockerfile_test_cross_compile": {"--custom-platform=linux/" + crossCompileArch},
 	"Dockerfile_test_issue_mz529":   {"--cleanup"},
 	"Dockerfile_test_issue_mz595":   {"--cleanup"},
 	"Dockerfile_test_issue_mz661":   {"--secret=id=kaniko,src=/kaniko/executor"},
@@ -218,10 +218,17 @@ var expectErr = map[string]int{
 	"Dockerfile_test_add_404":       1,
 }
 
+var crossCompileArch = func() string {
+	if runtime.GOARCH == "amd64" {
+		return "arm64"
+	}
+	return "amd64"
+}()
+
 // Platform overrides for docker pull and diffoci, keyed by test name.
 var platformMap = map[string]v1.Platform{
-	"TestRun/test_Dockerfile_test_cross_compile":          {OS: "linux", Architecture: "arm64"},
-	"TestLayers/test_layer_Dockerfile_test_cross_compile": {OS: "linux", Architecture: "arm64"},
+	"TestRun/test_Dockerfile_test_cross_compile":          {OS: "linux", Architecture: crossCompileArch},
+	"TestLayers/test_layer_Dockerfile_test_cross_compile": {OS: "linux", Architecture: crossCompileArch},
 }
 
 // Arguments to diffoci when comparing dockerfiles
@@ -237,7 +244,7 @@ var diffArgsMap = map[string][]string{
 	"TestRun/test_Dockerfile_test_add": {"--extra-ignore-file-permissions"},
 	// Verify we don't store root directory
 	"TestRun/test_Dockerfile_test_root":          {"--extra-ignore-layer-length-mismatch=false"},
-	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/arm64"},
+	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/" + crossCompileArch},
 	// --ignore-path must suppress the kaniko-only file; layer-length-mismatch would mask the difference
 	"TestRun/test_Dockerfile_test_ignore_path": {"--extra-ignore-layer-length-mismatch=false"},
 	// FROM scratch we start with root, buildkit doesnt

--- a/integration/images.go
+++ b/integration/images.go
@@ -202,6 +202,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	// mz511: we're using /etc/nsswitch.conf because it pre-exists
 	// in the kaniko image and can therefore safely be deleted.
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=/etc/nsswitch.conf"},
+	"Dockerfile_test_ignore_path":  {"--ignore-path=/kaniko-extra-file", "--ignore-path=/kaniko-extra-dir"},
 	"Dockerfile_test_issue_mz529": {"--cleanup"},
 	"Dockerfile_test_issue_mz595": {"--cleanup"},
 	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=/kaniko/executor"},
@@ -225,6 +226,8 @@ var diffArgsMap = map[string][]string{
 	"TestRun/test_Dockerfile_test_add": {"--extra-ignore-file-permissions"},
 	// Verify we don't store root directory
 	"TestRun/test_Dockerfile_test_root": {"--extra-ignore-layer-length-mismatch=false"},
+	// --ignore-path must suppress the kaniko-only file; layer-length-mismatch would mask the difference
+	"TestRun/test_Dockerfile_test_ignore_path": {"--extra-ignore-layer-length-mismatch=false"},
 	// FROM scratch we start with root, buildkit doesnt
 	"TestRun/test_Dockerfile_test_workdir_with_user": {"--extra-ignore-file-permissions"},
 	// We don't handle user nobody=-1 nogroup=-1 correctly

--- a/integration/images.go
+++ b/integration/images.go
@@ -120,6 +120,7 @@ var KanikoEnv = []string{
 	"FF_KANIKO_RUN_MOUNT_BIND=1",
 	"FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY=1",
 	"FF_KANIKO_CACHE_LOOKAHEAD=1",
+	"KANIKO_PRINT_PLAN=1",
 }
 
 var WarmerEnv = []string{

--- a/integration/images.go
+++ b/integration/images.go
@@ -883,6 +883,11 @@ func buildKanikoImage(
 
 	// build kaniko image
 	additionalFlags := append(buildArgs, kanikoArgs...)
+	additionalFlags = append(additionalFlags,
+		"--digest-file=/dev/stdout",
+		"--image-name-with-digest-file=/dev/stdout",
+		"--image-name-tag-with-digest-file=/dev/stdout",
+	)
 	logf("Going to build image with kaniko: %s, flags: %s \n", kanikoImage, additionalFlags)
 
 	dockerRunFlags := []string{

--- a/integration/images.go
+++ b/integration/images.go
@@ -204,7 +204,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	// mz511: we're using /etc/nsswitch.conf because it pre-exists
 	// in the kaniko image and can therefore safely be deleted.
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=/etc/nsswitch.conf"},
-	"Dockerfile_test_ignore_path":  {"--ignore-path=/kaniko-extra-file", "--ignore-path=/kaniko-extra-dir"},
+	"Dockerfile_test_ignore_path": {"--ignore-path=/kaniko-extra-file", "--ignore-path=/kaniko-extra-dir"},
 	"Dockerfile_test_issue_mz529": {"--cleanup"},
 	"Dockerfile_test_issue_mz595": {"--cleanup"},
 	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=/kaniko/executor"},

--- a/integration/images.go
+++ b/integration/images.go
@@ -202,6 +202,7 @@ var additionalKanikoFlagsMap = map[string][]string{
 	// in the kaniko image and can therefore safely be deleted.
 	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=/etc/nsswitch.conf"},
 	"Dockerfile_test_issue_mz529": {"--cleanup"},
+	"Dockerfile_test_issue_mz595": {"--cleanup"},
 	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=/kaniko/executor"},
 }
 

--- a/integration/images.go
+++ b/integration/images.go
@@ -204,12 +204,12 @@ var additionalKanikoFlagsMap = map[string][]string{
 	"Dockerfile_test_issue_cg188":            {"--secret=id=netrc,env=SECRET"},
 	// mz511: we're using /etc/nsswitch.conf because it pre-exists
 	// in the kaniko image and can therefore safely be deleted.
-	"Dockerfile_test_issue_mz511": {"--secret=id=netrc,src=/etc/nsswitch.conf"},
-	"Dockerfile_test_ignore_path":    {"--ignore-path=/kaniko-extra-file", "--ignore-path=/kaniko-extra-dir"},
+	"Dockerfile_test_issue_mz511":   {"--secret=id=netrc,src=/etc/nsswitch.conf"},
+	"Dockerfile_test_ignore_path":   {"--ignore-path=/kaniko-extra-file", "--ignore-path=/kaniko-extra-dir"},
 	"Dockerfile_test_cross_compile": {"--custom-platform=linux/arm64"},
-	"Dockerfile_test_issue_mz529": {"--cleanup"},
-	"Dockerfile_test_issue_mz595": {"--cleanup"},
-	"Dockerfile_test_issue_mz661": {"--secret=id=kaniko,src=/kaniko/executor"},
+	"Dockerfile_test_issue_mz529":   {"--cleanup"},
+	"Dockerfile_test_issue_mz595":   {"--cleanup"},
+	"Dockerfile_test_issue_mz661":   {"--secret=id=kaniko,src=/kaniko/executor"},
 }
 
 var expectErr = map[string]int{
@@ -234,7 +234,7 @@ var diffArgsMap = map[string][]string{
 	// when we untar we overwrite the parent directory, buildkit doesnt
 	"TestRun/test_Dockerfile_test_add": {"--extra-ignore-file-permissions"},
 	// Verify we don't store root directory
-	"TestRun/test_Dockerfile_test_root":           {"--extra-ignore-layer-length-mismatch=false"},
+	"TestRun/test_Dockerfile_test_root":          {"--extra-ignore-layer-length-mismatch=false"},
 	"TestRun/test_Dockerfile_test_cross_compile": {"--platform=linux/arm64"},
 	// --ignore-path must suppress the kaniko-only file; layer-length-mismatch would mask the difference
 	"TestRun/test_Dockerfile_test_ignore_path": {"--extra-ignore-layer-length-mismatch=false"},

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1288,18 +1288,18 @@ func meetsRequirements() bool {
 // containerDiff compares the container images image1 and image2.
 func containerDiff(t *testing.T, image1, image2 string, flags ...string) {
 	// workaround for container-diff OCI issue https://github.com/GoogleContainerTools/container-diff/issues/389
-	dockerPullCmd := exec.Command("docker", "pull", image1)
-	out := RunCommand(dockerPullCmd, t)
+	pullArgs := append([]string{"pull"}, platformMap[t.Name()]...)
+	out := RunCommand(exec.Command("docker", append(pullArgs, image1)...), t)
 	t.Logf("docker pull cmd output for image1 = %s", string(out))
 	image1 = daemonPrefix + image1
 
-	dockerPullCmd = exec.Command("docker", "pull", image2)
-	out = RunCommand(dockerPullCmd, t)
+	out = RunCommand(exec.Command("docker", append(pullArgs, image2)...), t)
 	t.Logf("docker pull cmd output for image2 = %s", string(out))
 	image2 = daemonPrefix + image2
 
 	flags = append([]string{"diff"}, flags...)
 	flags = append(flags, image1, image2, "--ignore-image-name", "--ignore-image-timestamps")
+	flags = append(flags, platformMap[t.Name()]...)
 	flags = append(flags, diffArgsMap[t.Name()]...)
 
 	containerdiffCmd := exec.Command("diffoci", flags...)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1086,25 +1086,34 @@ func TestBuildWithAnnotations(t *testing.T) {
 }
 
 func onBuildDiff(t *testing.T, image1, image2 string) {
-	img1, err := getImageConfig(image1)
+	opts := platformRemoteOpts(t.Name())
+	img1, err := getImageConfig(image1, opts...)
 	if err != nil {
 		t.Fatalf("Failed to get image config for (%s): %s", image1, err)
 	}
-	img2, err := getImageConfig(image2)
+	img2, err := getImageConfig(image2, opts...)
 	if err != nil {
 		t.Fatalf("Failed to get image config for (%s): %s", image2, err)
 	}
 	testutil.CheckDeepEqual(t, img1.Config.OnBuild, img2.Config.OnBuild)
 }
 
+func platformRemoteOpts(testName string) []remote.Option {
+	if p, ok := platformMap[testName]; ok {
+		return []remote.Option{remote.WithPlatform(p)}
+	}
+	return nil
+}
+
 func checkLayers(t *testing.T, image1, image2 string, offset int) {
 	t.Helper()
-	img1, err := getImageDetails(image1)
+	opts := platformRemoteOpts(t.Name())
+	img1, err := getImageDetails(image1, opts...)
 	if err != nil {
 		t.Fatalf("Couldn't get details from image reference for (%s): %s", image1, err)
 	}
 
-	img2, err := getImageDetails(image2)
+	img2, err := getImageDetails(image2, opts...)
 	if err != nil {
 		t.Fatalf("Couldn't get details from image reference for (%s): %s", image2, err)
 	}
@@ -1115,12 +1124,12 @@ func checkLayers(t *testing.T, image1, image2 string, offset int) {
 	}
 }
 
-func getImageConfig(image string) (*v1.ConfigFile, error) {
+func getImageConfig(image string, opts ...remote.Option) (*v1.ConfigFile, error) {
 	ref, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't parse reference to image %s: %w", image, err)
 	}
-	imgRef, err := remote.Image(ref)
+	imgRef, err := remote.Image(ref, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get reference to image %s from remote: %w", image, err)
 	}
@@ -1131,16 +1140,16 @@ func getImageConfig(image string) (*v1.ConfigFile, error) {
 	return cfg, nil
 }
 
-func getImage(image string) (v1.Image, error) {
+func getImage(image string, opts ...remote.Option) (v1.Image, error) {
 	ref, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't parse reference to image %s: %w", image, err)
 	}
-	return remote.Image(ref)
+	return remote.Image(ref, opts...)
 }
 
-func getImageDetails(image string) (*imageDetails, error) {
-	imgRef, err := getImage(image)
+func getImageDetails(image string, opts ...remote.Option) (*imageDetails, error) {
+	imgRef, err := getImage(image, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get reference to image %s from remote: %w", image, err)
 	}
@@ -1288,7 +1297,13 @@ func meetsRequirements() bool {
 // containerDiff compares the container images image1 and image2.
 func containerDiff(t *testing.T, image1, image2 string, flags ...string) {
 	// workaround for container-diff OCI issue https://github.com/GoogleContainerTools/container-diff/issues/389
-	pullArgs := append([]string{"pull"}, platformMap[t.Name()]...)
+	var pullArgs []string
+	if p, ok := platformMap[t.Name()]; ok {
+		platformFlag := fmt.Sprintf("--platform=%s/%s", p.OS, p.Architecture)
+		pullArgs = append(pullArgs, platformFlag)
+		flags = append(flags, platformFlag)
+	}
+	pullArgs = append([]string{"pull"}, pullArgs...)
 	out := RunCommand(exec.Command("docker", append(pullArgs, image1)...), t)
 	t.Logf("docker pull cmd output for image1 = %s", string(out))
 	image1 = daemonPrefix + image1
@@ -1299,7 +1314,6 @@ func containerDiff(t *testing.T, image1, image2 string, flags ...string) {
 
 	flags = append([]string{"diff"}, flags...)
 	flags = append(flags, image1, image2, "--ignore-image-name", "--ignore-image-timestamps")
-	flags = append(flags, platformMap[t.Name()]...)
 	flags = append(flags, diffArgsMap[t.Name()]...)
 
 	containerdiffCmd := exec.Command("diffoci", flags...)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -747,6 +748,39 @@ func TestReplaceFolderWithFileOrLink(t *testing.T) {
 					t.Errorf("Last layer should not add whiteout files to deleted directory but found %s", file)
 				}
 			}
+		})
+	}
+}
+
+func TestSnapshotModes(t *testing.T) {
+	t.Parallel()
+	const dockerfile = "Dockerfile_test_run"
+
+	_, ex, _, _ := runtime.Caller(0)
+	cwd := filepath.Dir(ex)
+
+	buildArgs := []string{
+		"--build-arg", "file=/file",
+		"--build-arg", "IMAGE_REPO=" + config.imageRepo,
+	}
+
+	build := func(t *testing.T, mode string) string {
+		t.Helper()
+		tag := GetKanikoImage(config.imageRepo, dockerfile+"-snapshot-"+mode)
+		kanikoArgs := []string{"-c", buildContextPath, "--snapshot-mode=" + mode}
+		if _, err := buildKanikoImage(t.Logf, dockerfilesPath, dockerfile, buildArgs, kanikoArgs, tag, cwd, config.gcsBucket, config.gcsClient, config.serviceAccount, false); err != nil {
+			t.Fatalf("kaniko build with --snapshot-mode=%s: %v", mode, err)
+		}
+		return tag
+	}
+
+	refImage := build(t, "full")
+
+	for _, mode := range []string{"redo", "time"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			modeImage := build(t, mode)
+			containerDiff(t, refImage, modeImage, "--ignore-timestamps")
 		})
 	}
 }

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -931,8 +931,14 @@ func DoBuild(opts *config.KanikoOptions) (image v1.Image, retErr error) {
 	logrus.Infof("Built cross stage deps: %v", crossStageDependencies)
 
 	util.Assert("executor.build.stages-nonempty", len(kanikoStages) > 0, "no stages to build")
-	if opts.Dryrun {
-		return nil, RenderStages(kanikoStages, opts, fileContext, crossStageDependencies)
+	if opts.Dryrun || config.EnvBool("KANIKO_PRINT_PLAN") {
+		err := RenderStages(kanikoStages, opts, fileContext, crossStageDependencies)
+		if err != nil {
+			return nil, err
+		}
+		if opts.Dryrun {
+			return nil, nil
+		}
 	}
 
 	// Some stages may refer to other random images, not previous stages


### PR DESCRIPTION
Closes #668

Subtle tweaks to our existing integration tests to broaden coverage on option-gated paths in `build.go`.
https://app.codecov.io/gh/osscontainertools/kaniko/pull/669/indirect-changes

## What this adds

| Flag / feature | How it is tested | Code covered |
|---|---|---|
| `--preserve-context` + `--cleanup` | adds `--cleanup` to the existing alpine-executor test (`mz595`), which already runs with `KANIKO_PRESERVE_CONTEXT=1` baked in | [`build.go:1008–1042`](https://github.com/osscontainertools/kaniko/blob/main/pkg/executor/build.go#L1008-L1042) |
| `KANIKO_PRINT_PLAN=1` | added to global `KanikoEnv`, so `RenderStages` is exercised on every build | [`build.go:848`](https://github.com/osscontainertools/kaniko/blob/main/pkg/executor/build.go#L848) |
| `--ignore-path` | new `Dockerfile_test_ignore_path` with two kaniko-only extra files; wired with `--ignore-path` flags and `--extra-ignore-layer-length-mismatch=false` so absence is verifiable | [`root.go:180`](https://github.com/osscontainertools/kaniko/blob/main/cmd/executor/cmd/root.go#L180) |
| `SHELL`, `STOPSIGNAL`, `HEALTHCHECK` | new Dockerfiles exercising each instruction, wired into `TestRun` | [`shell.go:31`](https://github.com/osscontainertools/kaniko/blob/main/pkg/commands/shell.go#L31), [`stopsignal.go:34`](https://github.com/osscontainertools/kaniko/blob/main/pkg/commands/stopsignal.go#L34), [`healthcheck.go:42`](https://github.com/osscontainertools/kaniko/blob/main/pkg/commands/healthcheck.go#L42) |
| `--snapshot-mode=time` | new `TestSnapshotModes` builds `Dockerfile_test_run` three times (`full`, `redo`, `time`) and compares all three outputs with `diffoci --ignore-file-timestamps` | [`build.go:83`](https://github.com/osscontainertools/kaniko/blob/main/pkg/executor/build.go#L83), [`build.go:1348–1360`](https://github.com/osscontainertools/kaniko/blob/main/pkg/executor/build.go#L1348-L1360) |
| `--custom-platform` | new `Dockerfile_test_cross_compile` — two-stage arm64 build with cross-stage `COPY`, no `RUN`; new `platformMap` propagates the platform to both `docker pull` and `diffoci` | [`build.go:1108–1118`](https://github.com/osscontainertools/kaniko/blob/main/pkg/executor/build.go#L1108-L1118) |
