### PR TITLE
docs overhaul - part 2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ We are doing our best to get to this. Please help us by helping us prioritize yo
 
  | **Description** | **Yes/No** |
  |----------------|---------------|
- | Please check if this a new feature you are proposing        | <ul><li>- [ ] </li></ul>|
+ | Please check if this is a new feature you are proposing        | <ul><li>- [ ] </li></ul>|
  | Please check if the build works in docker but not in kaniko | <ul><li>- [ ] </li></ul>|
  | Please check if this error is seen when you use `--cache` flag | <ul><li>- [ ] </li></ul>|
  | Please check if your dockerfile is a multistage dockerfile | <ul><li>- [ ] </li></ul>|

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
 
 
-Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_
+Fixes mzNNN _in case of a bug fix, this should point to a bug and any other related issue(s)_
 
 **Description**
 
@@ -13,8 +13,7 @@ your descriptive commit message(s)! -->
 These are the criteria that every PR should meet, please check them off as you
 review them:
 
-- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
-- [ ] Adds integration tests if needed.
+- [ ] Adds integration tests if the output changes, or golden tests if the build plan changes.
 
 _See [the contribution guide](../CONTRIBUTING.md) for more details._
 
@@ -22,7 +21,7 @@ _See [the contribution guide](../CONTRIBUTING.md) for more details._
 **Reviewer Notes**
 
 - [ ] The code flow looks good.
-- [ ] Unit tests and or integration tests added.
+- [ ] Integration or golden tests added where appropriate.
 
 
 **Release Notes**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
 
 
-Fixes mzNNN _in case of a bug fix, this should point to a bug and any other related issue(s)_
+Fixes #NNN _in case of a bug fix, this should point to a bug and any other related issue(s)_
 
 **Description**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,16 +35,10 @@ Reference the related issue in the subject using a short prefix to indicate whic
 | `cgNNN` | Chainguard fork (`chainguard-dev/kaniko`) |
 | `NNN` (no prefix) | Original Google repository (`GoogleContainerTools/kaniko`) |
 
-Include the PR number in parentheses at the end of the subject line:
-
-```
-mz661: resolve secrets before moving kaniko dir (#662)
-```
-
 For bug fixes, add a body paragraph explaining what the bug was and how the fix works:
 
 ```
-mz661: resolve secrets before moving kaniko dir (#662)
+mz661: resolve secrets before moving kaniko dir
 
 When KANIKO_DIR is set to a path other than the executor directory,
 moveKanikoDir relocates all files under the original kaniko dir before

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,6 @@ In this file you'll find info on:
     - [Commit Messages](#commit-messages)
     - [Coding standards](#coding-standards)
   - [Finding something to work on](#finding-something-to-work-on)
-  [code](#coding-standards)
-- [Finding something to work on](#finding-something-to-work-on)
 
 ## Code reviews
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,7 @@ Reference the related issue in the subject using a short prefix to indicate whic
 | `cgNNN` | Chainguard fork (`chainguard-dev/kaniko`) |
 | `NNN` (no prefix) | Original Google repository (`GoogleContainerTools/kaniko`) |
 
-For bug fixes, add a body paragraph describing the incorrect behavior and why the fix resolves it:
-
-```
-mz123: short description of the fix
-
-Description of what was going wrong and why this change corrects it.
-```
+For bug fixes, add a body paragraph describing the incorrect behavior and why the fix resolves it.
 
 For simple changes with no associated issue, a subject line alone is fine.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,15 +38,9 @@ Reference the related issue in the subject using a short prefix to indicate whic
 For bug fixes, add a body paragraph explaining what the bug was and how the fix works:
 
 ```
-mz661: resolve secrets before moving kaniko dir
+mz123: what was changed
 
-When KANIKO_DIR is set to a path other than the executor directory,
-moveKanikoDir relocates all files under the original kaniko dir before
-resolveSecrets runs. Any --secret with src= pointing into that dir is
-therefore missing by the time its path is read, causing the build to
-fail with "no such file or directory".
-
-The fix moves resolveSecrets before moveKanikoDir.
+What was the buggy behaviour and why does this fix it.
 ```
 
 For simple changes with no associated issue, a subject line alone is fine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,23 +26,35 @@ This section describes the standards we will try to maintain in this repo.
 
 ### Commit Messages
 
-All commit messages should follow
-[these best practices](https://chris.beams.io/posts/git-commit/), specifically:
+Reference the related issue in the subject using a short prefix to indicate which repository the issue lives in:
 
-- Start with a subject line
-- Contain a body that explains _why_ you're making the change you're making
-- Reference an issue number if one exists, closing it if applicable (with text
-  such as
-  ["Fixes #245" or "Closes #111"](https://help.github.com/articles/closing-issues-using-keywords/))
+| Prefix | Repository |
+|--------|-----------|
+| `mzNNN` | This repository (`osscontainertools/kaniko`, formerly `mzihlmann/kaniko`) |
+| `cgNNN` | Chainguard fork (`chainguard-dev/kaniko`) |
+| `NNN` (no prefix) | Original Google repository (`GoogleContainerTools/kaniko`) |
 
-Aim for [2 paragraphs in the body](https://www.youtube.com/watch?v=PJjmw9TRB7s).
-Not sure what to put? Include:
+Include the PR number in parentheses at the end of the subject line:
 
-- What is the problem being solved?
-- Why is this the best approach?
-- What other approaches did you consider?
-- What side effects will this approach have?
-- What future work remains to be done?
+```
+mz661: resolve secrets before moving kaniko dir (#662)
+```
+
+For bug fixes, add a body paragraph explaining what the bug was and how the fix works:
+
+```
+mz661: resolve secrets before moving kaniko dir (#662)
+
+When KANIKO_DIR is set to a path other than the executor directory,
+moveKanikoDir relocates all files under the original kaniko dir before
+resolveSecrets runs. Any --secret with src= pointing into that dir is
+therefore missing by the time its path is read, causing the build to
+fail with "no such file or directory".
+
+The fix moves resolveSecrets before moveKanikoDir.
+```
+
+For simple changes with no associated issue, a subject line alone is fine.
 
 ### Coding standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,8 @@ In this file you'll find info on:
   - [Code reviews](#code-reviews)
   - [Standards](#standards)
     - [Commit Messages](#commit-messages)
-    - [Coding standards](#coding-standards)
+    - [Feature flags](#feature-flags)
+  - [Coding standards](#coding-standards)
   - [Finding something to work on](#finding-something-to-work-on)
 
 ## Code reviews
@@ -55,6 +56,10 @@ The fix moves resolveSecrets before moveKanikoDir.
 ```
 
 For simple changes with no associated issue, a subject line alone is fine.
+
+### Feature flags
+
+New behavior that would change kaniko's output or semantics must ship behind a feature flag rather than directly. This keeps patch releases stable. See [docs/releases.md](docs/releases.md) for the full policy and a guide on when a feature flag is needed.
 
 ### Coding standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,12 @@ Reference the related issue in the subject using a short prefix to indicate whic
 | `cgNNN` | Chainguard fork (`chainguard-dev/kaniko`) |
 | `NNN` (no prefix) | Original Google repository (`GoogleContainerTools/kaniko`) |
 
-For bug fixes, add a body paragraph explaining what the bug was and how the fix works:
+For bug fixes, add a body paragraph describing the incorrect behavior and why the fix resolves it:
 
 ```
-mz123: what was changed
+mz123: short description of the fix
 
-What was the buggy behaviour and why does this fix it.
+Description of what was going wrong and why this change corrects it.
 ```
 
 For simple changes with no associated issue, a subject line alone is fine.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,7 +119,9 @@ kaniko has [unit tests](#unit-tests), [golden tests](#golden-tests), and [integr
 Please note that the tests require a Linux machine - use Vagrant to quickly set
 up the test environment needed if you work with macOS or Windows.
 
-**What to add when contributing:** every change that affects the output of a build should be covered by a new integration test Dockerfile. Changes that affect the build plan but not the output (flow optimizations, caching logic) should be covered by a golden test. Unit tests are useful for development and debugging, but we do not add new ones: they verify that code behaves the same as before in specific scenarios, not that it is correct. The value of a test is inversely proportional to the number of mocks it involves.
+**What to add when contributing:** every change that affects the output of a build should be covered by a new integration test Dockerfile. Changes that affect the build plan but not the output (flow optimizations, caching logic) should be covered by a golden test. Unit tests are useful for development and debugging, but we do not add new ones: they verify that code behaves the same as before in specific scenarios, not that it is correct.
+
+> The value of a test is inversely proportional to the number of mocks it involves.
 
 ### Unit Tests
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,13 +31,13 @@ cmd/
   warmer/         # cache warmer entry point
 pkg/
   commands/       # Dockerfile command implementations (COPY, RUN, ADD, …)
-  executor/       # core build logic — build.go is the heart of the build loop
+  executor/       # core build logic (build.go is the heart of the build loop)
   snapshot/       # filesystem snapshotting
   dockerfile/     # Dockerfile parsing
   buildcontext/   # build context sources (local, GCS, S3, git, …)
   image/          # image pulling and pushing
   cache/          # cache lookup (remote layer cache and warmer-primed base images)
-  warmer/         # warmer implementation — populates the local base image cache
+  warmer/         # warmer implementation, populates the local base image cache
   util/           # shared utilities
 deploy/           # Dockerfiles for the published kaniko images
 integration/      # integration tests and test Dockerfiles
@@ -81,7 +81,7 @@ Note that the resulting binary cannot and should not be run directly on your hos
 After `make`, the executor binary is at `out/executor`. Mount it into the debug image to run your local build:
 
 ```shell
-# Build only — no push, useful for quick iteration
+# Build only, no push, useful for quick iteration
 docker run --rm \
   -v $(pwd)/out/executor:/kaniko/executor \
   -v $(pwd)/integration:/workspace \
@@ -102,7 +102,7 @@ docker run --network=host --rm \
 
 Swap in any Dockerfile from `integration/dockerfiles/` or write your own.
 
-Note: `run_in_docker.sh` in the repo root is a different tool — it runs the published kaniko image against a user-provided Dockerfile and is not intended for testing local code changes.
+Note: `run_in_docker.sh` in the repo root is a different tool. It runs the published kaniko image against a user-provided Dockerfile and is not intended for testing local code changes.
 
 ## Verifying kaniko builds
 
@@ -129,7 +129,7 @@ make test
 
 ### Golden Tests
 
-Golden tests verify the build plan kaniko computes for a given Dockerfile — the sequence of stages, steps, and cache keys it would execute — without actually building anything. See [testplan.md](docs/testplan.md) for more detail on what they cover.
+Golden tests verify the build plan kaniko computes for a given Dockerfile (the sequence of stages, steps, and cache keys it would execute) without actually building anything. See [testplan.md](docs/testplan.md) for more detail on what they cover.
 
 Run them with:
 
@@ -276,7 +276,7 @@ profiling,
 When you have changes you would like to propose to kaniko, you will need to:
 
 1. Ensure the commit message(s) follow the style described in [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages)
-1. If your change introduces new behavior, wrap it in a feature flag — see [docs/releases.md](docs/releases.md) for when this is required
+1. If your change introduces new behavior, wrap it in a feature flag. See [docs/releases.md](docs/releases.md) for when this is required
 1. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
 
 ### Reviews

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,6 +119,8 @@ kaniko has [unit tests](#unit-tests), [golden tests](#golden-tests), and [integr
 Please note that the tests require a Linux machine - use Vagrant to quickly set
 up the test environment needed if you work with macOS or Windows.
 
+**What to add when contributing:** every change that affects the output of a build should be covered by a new integration test Dockerfile. Changes that affect the build plan but not the output (flow optimizations, caching logic) should be covered by a golden test. Unit tests are useful for development and debugging, but we do not add new ones: they verify that code behaves the same as before in specific scenarios, not that it is correct. The value of a test is inversely proportional to the number of mocks it involves.
+
 ### Unit Tests
 
 The unit tests live with the code they test and can be run with:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,6 +14,7 @@ First you will need to setup your GitHub account and create a fork:
 
 Once you have those, you can iterate on kaniko:
 
+1. [Build kaniko](#building-kaniko)
 1. [Run your instance of kaniko](README.md#running-kaniko)
 1. [Verifying kaniko builds](#verifying-kaniko-builds)
 1. [Run kaniko tests](#testing-kaniko)
@@ -22,9 +23,6 @@ When you're ready, you can [create a PR](#creating-a-pr)!
 
 ## Checkout your fork
 
-The Go tools require that you clone the repository to the `src/github.com/osscontainertools/kaniko` directory
-in your [`GOPATH`](https://go.dev/wiki/SettingGOPATH).
-
 To check out this repository:
 
 1. Create your own [fork of this
@@ -32,8 +30,6 @@ To check out this repository:
 2. Clone it to your machine:
 
   ```shell
-  mkdir -p ${GOPATH}/src/github.com/osscontainertools
-  cd ${GOPATH}/src/github.com/osscontainertools
   git clone git@github.com:${YOUR_GITHUB_USERNAME}/kaniko.git
   cd kaniko
   git remote add upstream git@github.com:osscontainertools/kaniko.git
@@ -42,6 +38,16 @@ To check out this repository:
 
 _Adding the `upstream` remote sets you up nicely for regularly [syncing your
 fork](https://help.github.com/articles/syncing-a-fork/)._
+
+## Building kaniko
+
+Build the kaniko executor binary with:
+
+```shell
+make
+```
+
+Note that the resulting binary cannot and should not be run directly on your host machine. As part of a normal build, kaniko performs destructive filesystem operations that are safe only inside a container. See [Running kaniko](README.md#running-kaniko) for how to run it.
 
 ## Verifying kaniko builds
 
@@ -128,13 +134,14 @@ Then you can launch integration tests as follows:
 make integration-test
 ```
 
-You can also run tests with `go test`, for example to run tests individually:
+You can also run individual test suites:
 
 ```shell
-go test ./integration -v --bucket $GCS_BUCKET --repo $IMAGE_REPO -run TestLayers/test_layer_Dockerfile_test_copy_bucket
+make integration-test-layers
+make integration-test-run
+make integration-test-k8s
+make integration-test-misc
 ```
-
-These tests will be kicked off by [reviewers](#reviews) for submitted PRs by the kokoro task.
 
 #### Local integration tests
 
@@ -166,7 +173,7 @@ of each run to that file location.
 ```shell
 docker run -v $(pwd):/workspace -v ~/.config:/root/.config \
 -e BENCHMARK_FILE=/workspace/benchmark_file \
-<YOUR-REGISTRY>/<YOUR-REPO>/<KANIKO-EXECUTOR> \
+ghcr.io/osscontainertools/kaniko:latest \
 --dockerfile=<path to Dockerfile> --context=/workspace \
 --destination=<YOUR-REGISTRY>/<YOUR-REPO>/new-image
 ```
@@ -177,29 +184,14 @@ Additionally, the integration tests can output benchmarking information to a `be
 BENCHMARK=true go test -v --bucket $GCS_BUCKET --repo $IMAGE_REPO
 ```
 
-#### Benchmarking your GCB runs
-If you are GCB builds are slow, you can check which phases in kaniko are bottlenecks or taking more time.
-To do this, add "BENCHMARK_ENV" to your cloudbuild.yaml like this.
-```shell script
-steps:
-- name: '<YOUR-REGISTRY>/<YOUR-REPO>/<KANIKO-EXECUTOR>'
-  args:
-  - --build-arg=NUM=${_COUNT}
-  - --no-push
-  - --snapshot-mode=redo
-  env:
-  - 'BENCHMARK_FILE=gs://$PROJECT_ID/gcb/benchmark_file'
-```
-You can download the file `gs://$PROJECT_ID/gcb/benchmark_file` using `gsutil cp` command.
-
 #### Profiling
 
-If your builds are taking long, we recently added support to analyze kaniko
-function calls using [Slow Jam](https://github.com/google/slowjam) To start
+If your builds are taking long, you can analyze kaniko
+function calls using [Slow Jam](https://github.com/google/slowjam). To start
 profiling,
 
 1. Add an environment variable `STACKLOG_PATH` to your
-   [pod definition](https://github.com/osscontainertools/kaniko/blob/master/examples/pod-build-profile.yaml#L15).
+   [pod definition](https://github.com/osscontainertools/kaniko/blob/main/examples/pod-build-profile.yaml#L15).
 2. If you are using the kaniko `debug` image, you can copy the file in the
    `pre-stop` container lifecycle hook.
 
@@ -215,6 +207,4 @@ When you have changes you would like to propose to kaniko, you will need to:
 
 ### Reviews
 
-Each PR must be reviewed by a maintainer. This maintainer will add the `kokoro:run` label
-to a PR to kick of [the integration tests](#integration-tests), which must pass for the PR
-to be submitted.
+Each PR must be reviewed by a maintainer. Maintainers will trigger [the integration tests](#integration-tests) in CI, which must pass for the PR to be submitted.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,6 +5,8 @@ This doc explains the development workflow so you can get started
 
 ## Getting started
 
+You will need [Go 1.26+](https://go.dev/dl/) and [Docker](https://docs.docker.com/install/) installed.
+
 First you will need to setup your GitHub account and create a fork:
 
 1. Create [a GitHub account](https://github.com/join)
@@ -15,11 +17,36 @@ First you will need to setup your GitHub account and create a fork:
 Once you have those, you can iterate on kaniko:
 
 1. [Build kaniko](#building-kaniko)
-1. [Run your instance of kaniko](README.md#running-kaniko)
+1. [Test your changes](#testing-your-changes)
 1. [Verifying kaniko builds](#verifying-kaniko-builds)
 1. [Run kaniko tests](#testing-kaniko)
 
 When you're ready, you can [create a PR](#creating-a-pr)!
+
+## Repository structure
+
+```
+cmd/
+  executor/       # kaniko executor entry point
+  warmer/         # cache warmer entry point
+pkg/
+  commands/       # Dockerfile command implementations (COPY, RUN, ADD, …)
+  executor/       # core build logic — build.go is the heart of the build loop
+  snapshot/       # filesystem snapshotting
+  dockerfile/     # Dockerfile parsing
+  buildcontext/   # build context sources (local, GCS, S3, git, …)
+  image/          # image pulling and pushing
+  cache/          # cache lookup (remote layer cache and warmer-primed base images)
+  warmer/         # warmer implementation — populates the local base image cache
+  util/           # shared utilities
+deploy/           # Dockerfiles for the published kaniko images
+integration/      # integration tests and test Dockerfiles
+golden/           # golden tests and their snapshots
+examples/         # example Kubernetes manifests
+docs/             # documentation
+```
+
+If you are fixing a Dockerfile command bug, start in `pkg/commands/`. If you are working on snapshotting or layer output, start in `pkg/snapshot/`. For the overall build flow, start in `pkg/executor/build.go`.
 
 ## Checkout your fork
 
@@ -49,6 +76,34 @@ make
 
 Note that the resulting binary cannot and should not be run directly on your host machine. As part of a normal build, kaniko performs destructive filesystem operations that are safe only inside a container. See [Running kaniko](README.md#running-kaniko) for how to run it.
 
+## Testing your changes
+
+After `make`, the executor binary is at `out/executor`. Mount it into the debug image to run your local build:
+
+```shell
+# Build only — no push, useful for quick iteration
+docker run --rm \
+  -v $(pwd)/out/executor:/kaniko/executor \
+  -v $(pwd)/integration:/workspace \
+  ghcr.io/osscontainertools/kaniko:debug \
+  --context /workspace \
+  --dockerfile /workspace/dockerfiles/Dockerfile_test_issue_new \
+  --no-push
+
+# Build and push to a local registry
+docker run --network=host --rm \
+  -v $(pwd)/out/executor:/kaniko/executor \
+  -v $(pwd)/integration:/workspace \
+  ghcr.io/osscontainertools/kaniko:debug \
+  --context /workspace \
+  --dockerfile /workspace/dockerfiles/Dockerfile_test_issue_new \
+  --destination localhost:5000/test
+```
+
+Swap in any Dockerfile from `integration/dockerfiles/` or write your own.
+
+Note: `run_in_docker.sh` in the repo root is a different tool — it runs the published kaniko image against a user-provided Dockerfile and is not intended for testing local code changes.
+
 ## Verifying kaniko builds
 
 Images built with kaniko should be no different from images built elsewhere.
@@ -59,7 +114,7 @@ While you iterate on kaniko, you can verify images built with kaniko by:
 
 ## Testing kaniko
 
-kaniko has both [unit tests](#unit-tests) and [integration tests](#integration-tests).
+kaniko has [unit tests](#unit-tests), [golden tests](#golden-tests), and [integration tests](#integration-tests).
 
 Please note that the tests require a Linux machine - use Vagrant to quickly set
 up the test environment needed if you work with macOS or Windows.
@@ -72,7 +127,27 @@ The unit tests live with the code they test and can be run with:
 make test
 ```
 
-_These tests will not run correctly unless you have [checked out your fork into your `$GOPATH`](#checkout-your-fork)._
+### Golden Tests
+
+Golden tests verify the build plan kaniko computes for a given Dockerfile — the sequence of stages, steps, and cache keys it would execute — without actually building anything. See [testplan.md](docs/testplan.md) for more detail on what they cover.
+
+Run them with:
+
+```shell
+make golden
+```
+
+If your change intentionally affects how kaniko plans a build, update the golden files:
+
+```shell
+UPDATE=1 make golden
+```
+
+To run a specific subset:
+
+```shell
+TESTS=<pattern> make golden
+```
 
 ### Lint Checks
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -275,9 +275,8 @@ profiling,
 
 When you have changes you would like to propose to kaniko, you will need to:
 
-1. Ensure the commit message(s) describe what issue you are fixing and how you are fixing it
-   (include references to [issue numbers](https://help.github.com/articles/closing-issues-using-keywords/)
-   if appropriate)
+1. Ensure the commit message(s) follow the style described in [CONTRIBUTING.md](CONTRIBUTING.md#commit-messages)
+1. If your change introduces new behavior, wrap it in a feature flag — see [docs/releases.md](docs/releases.md) for when this is required
 1. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
 
 ### Reviews

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Their focus is to keep dependencies up to date and patch security issues, keepin
 kaniko releases are published as images on [ghcr.io/osscontainertools/kaniko](https://github.com/orgs/osscontainertools/packages/container/package/kaniko) and on Docker Hub as [martizih/kaniko](https://hub.docker.com/r/martizih/kaniko).
 
 Release notes and source code archives are available on the [releases
-section](https://github.com/osscontainertools/kaniko/releases).
+section](https://github.com/osscontainertools/kaniko/releases). For the release cadence and feature flag graduation policy, see [docs/releases.md](docs/releases.md).
 
 Images available from other vendors:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dockerfile completely in userspace. This enables building container images in
 environments that can't easily or securely run a Docker daemon, such as a
 standard Kubernetes cluster.
 
-kaniko is meant to be run as an image: `martizih/kaniko:latest`. We do **not** recommend
+kaniko is meant to be run as an image: `ghcr.io/osscontainertools/kaniko:latest`. We do **not** recommend
 running the kaniko executor binary in another image, as it might not work as you
 expect - see [Known Issues](#known-issues).
 
@@ -341,7 +341,7 @@ Input data, using docker:
 
 ```shell
 echo -e 'FROM alpine \nRUN echo "created from standard input"' > Dockerfile | tar -cf - Dockerfile | gzip -9 | docker run \
-  --interactive -v $(pwd):/workspace <YOUR-REGISTRY>/<YOUR-REPO>/<KANIKO-EXECUTOR> \
+  --interactive -v $(pwd):/workspace ghcr.io/osscontainertools/kaniko:latest \
   --context tar://stdin \
   --destination=<YOUR-REGISTRY>/$project/$image:$tag>
 ```
@@ -353,14 +353,14 @@ completely dockerless:
 ```shell
 echo -e 'FROM alpine \nRUN echo "created from standard input"' > Dockerfile | tar -cf - Dockerfile | gzip -9 | kubectl run kaniko \
 --rm --stdin=true \
---image=<YOUR-REGISTRY>/<YOUR-REPO>/<KANIKO-EXECUTOR> --restart=Never \
+--image=ghcr.io/osscontainertools/kaniko:latest --restart=Never \
 --overrides='{
   "apiVersion": "v1",
   "spec": {
     "containers": [
       {
         "name": "kaniko",
-        "image": "<YOUR-REGISTRY>/<YOUR-REPO>/<KANIKO-EXECUTOR>",
+        "image": "ghcr.io/osscontainertools/kaniko:latest",
         "stdin": true,
         "stdinOnce": true,
         "args": [
@@ -448,7 +448,7 @@ metadata:
 spec:
   containers:
     - name: kaniko
-      image: <YOUR-REGISTRY>/<YOUR-REPO>/<KANIKO-EXECUTOR>
+      image: ghcr.io/osscontainertools/kaniko:latest
       args:
         - "--dockerfile=<path to Dockerfile within the build context>"
         - "--context=gs://<GCS bucket>/<path to .tar.gz>"
@@ -479,7 +479,7 @@ a container is running in gVisor.
 
 ```shell
 docker run --runtime=runsc -v $(pwd):/workspace -v ~/.config:/root/.config \
-<YOUR-REGISTRY>/<YOUR-REPO>/<KANIKO-EXECUTOR> \
+ghcr.io/osscontainertools/kaniko:latest \
 --dockerfile=<path to Dockerfile> --context=/workspace \
 --destination=<YOUR-REGISTRY>/<YOUR-REPO>/my-image --force
 ```
@@ -498,7 +498,7 @@ To run kaniko in GCB, add it to your build config as a build step:
 
 ```yaml
 steps:
-  - name: <YOUR-REGISTRY>/<YOUR-REPO>/<KANIKO-EXECUTOR>
+  - name: ghcr.io/osscontainertools/kaniko:latest
     args:
       [
         "--dockerfile=<path to Dockerfile within the build context>",
@@ -524,7 +524,7 @@ For example, when using gcloud and GCR you could run kaniko as follows:
 docker run \
     -v "$HOME"/.config/gcloud:/root/.config/gcloud \
     -v /path/to/context:/workspace \
-    gcr.io/kaniko-project/executor:latest \
+    ghcr.io/osscontainertools/kaniko:latest \
     --dockerfile /workspace/Dockerfile \
     --destination "gcr.io/$PROJECT_ID/$IMAGE_NAME:$TAG" \
     --context dir:///workspace/
@@ -591,7 +591,7 @@ build:
 ```
 This is just an illustrative extract, please find the full [.gitlab-ci.yml](./docs/bootstrap.gitlab-ci.yml) here.
 
-With this two step approach we can now indeed bootstrap kaniko in kaniko. However, it is not really necessary to rebuild that intermediate bootstrap image every time, we can reuse it from a different build. Hence I provide a dedicated image `martizih/kaniko:bootstrap` that can be used for that purpose.
+With this two step approach we can now indeed bootstrap kaniko in kaniko. However, it is not really necessary to rebuild that intermediate bootstrap image every time, we can reuse it from a different build. Hence I provide a dedicated image `ghcr.io/osscontainertools/kaniko:bootstrap` that can be used for that purpose.
 
 
 ### Caching
@@ -621,9 +621,9 @@ kaniko pod. To do so, the cache must first be populated, as it is read-only. We
 provide a kaniko cache warming image at `gcr.io/kaniko-project/warmer`:
 
 ```shell
-docker run -v $(pwd):/workspace gcr.io/kaniko-project/warmer:latest --cache-dir=/workspace/cache --image=<image to cache> --image=<another image to cache>
-docker run -v $(pwd):/workspace gcr.io/kaniko-project/warmer:latest --cache-dir=/workspace/cache --dockerfile=<path to dockerfile>
-docker run -v $(pwd):/workspace gcr.io/kaniko-project/warmer:latest --cache-dir=/workspace/cache --dockerfile=<path to dockerfile> --build-arg version=1.19
+docker run -v $(pwd):/workspace ghcr.io/osscontainertools/kaniko:warmer --cache-dir=/workspace/cache --image=<image to cache> --image=<another image to cache>
+docker run -v $(pwd):/workspace ghcr.io/osscontainertools/kaniko:warmer --cache-dir=/workspace/cache --dockerfile=<path to dockerfile>
+docker run -v $(pwd):/workspace ghcr.io/osscontainertools/kaniko:warmer --cache-dir=/workspace/cache --dockerfile=<path to dockerfile> --build-arg version=1.19
 ```
 
 `--image` can be specified for any number of desired images. `--dockerfile` can
@@ -1233,7 +1233,7 @@ the kaniko executor image along with a busybox shell to enter.
 You can launch the debug image with a shell entrypoint:
 
 ```shell
-docker run -it --entrypoint=/busybox/sh gcr.io/kaniko-project/executor:debug
+docker run -it --entrypoint=/busybox/sh ghcr.io/osscontainertools/kaniko:debug
 ```
 
 ## Security
@@ -1276,7 +1276,7 @@ Note that to verify images after v1.26.0 you require cosign v3.
 $ cosign verify \
   --certificate-identity-regexp "https://github.com/osscontainertools/kaniko/.github/workflows/images.yaml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  martizih/kaniko:latest
+  ghcr.io/osscontainertools/kaniko:latest
 ```
 
 kaniko images for older versions [1.24.1 - 1.25.5] can be verified using
@@ -1284,7 +1284,7 @@ kaniko images for older versions [1.24.1 - 1.25.5] can be verified using
 $ cosign verify \
   --certificate-identity-regexp "https://github.com/mzihlmann/kaniko/.github/workflows/images.yaml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  martizih/kaniko:latest
+  ghcr.io/osscontainertools/kaniko:latest
 ```
 
 ## Creating Multi-arch Container Manifests Using Kaniko and Manifest-tool
@@ -1354,7 +1354,7 @@ build-container:
     # run each build on a suitable, preconfigured runner (must match the target architecture)
     - runner-${ARCH}
   image:
-    name: gcr.io/kaniko-project/executor:debug
+    name: ghcr.io/osscontainertools/kaniko:debug
     entrypoint: [""]
   script:
     # build the container image for the current arch using kaniko

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -20,7 +20,7 @@ Get your docker registry user and password encoded in base64
 Create a `config.json` file with your Docker registry url and the previous
 generated base64 string
 
-**Note:** Please use v1 endpoint. See #1209 for more details
+**Note:** Please use the v1 endpoint. See [GoogleContainerTools/kaniko#1209](https://github.com/GoogleContainerTools/kaniko/issues/1209) for more details.
 
 ```json
 {
@@ -35,7 +35,7 @@ generated base64 string
 Run kaniko with the `config.json` inside `/kaniko/.docker/config.json`
 
 ```shell
-docker run -ti --rm -v `pwd`:/workspace -v `pwd`/config.json:/kaniko/.docker/config.json:ro gcr.io/kaniko-project/executor:latest --dockerfile=Dockerfile --destination=yourimagename
+docker run -ti --rm -v `pwd`:/workspace -v `pwd`/config.json:/kaniko/.docker/config.json:ro ghcr.io/osscontainertools/kaniko:latest --dockerfile=Dockerfile --destination=yourimagename
 ```
 
 ## Pushing to Google GCR
@@ -54,7 +54,7 @@ steps:
 
 ```shell
 docker run -ti --rm -e GOOGLE_APPLICATION_CREDENTIALS=/kaniko/config.json \
--v `pwd`:/workspace -v `pwd`/kaniko-secret.json:/kaniko/config.json:ro gcr.io/kaniko-project/executor:latest \
+-v `pwd`:/workspace -v `pwd`/kaniko-secret.json:/kaniko/config.json:ro ghcr.io/osscontainertools/kaniko:latest \
 --dockerfile=Dockerfile --destination=yourimagename
 ```
 
@@ -129,7 +129,7 @@ metadata:
 spec:
   containers:
     - name: kaniko
-      image: gcr.io/kaniko-project/executor:latest
+      image: ghcr.io/osscontainertools/kaniko:latest
       args:
         - "--dockerfile=<path to Dockerfile within the build context>"
         - "--context=s3://<bucket name>/<path to .tar.gz>"
@@ -211,7 +211,7 @@ metadata:
 spec:
   containers:
     - name: kaniko
-      image: gcr.io/kaniko-project/executor:latest
+      image: ghcr.io/osscontainertools/kaniko:latest
       args:
         - "--dockerfile=<path to Dockerfile within the build context>"
         - "--context=s3://<bucket name>/<path to .tar.gz>"
@@ -258,7 +258,7 @@ For example, for Artifactory cloud users, the docker registry should be:
 
 Run kaniko with the `config.json` inside `/kaniko/.docker/config.json`
 
-    docker run -ti --rm -v `pwd`:/workspace -v `pwd`/config.json:/kaniko/.docker/config.json:ro gcr.io/kaniko-project/executor:latest --dockerfile=Dockerfile --destination=yourimagename
+    docker run -ti --rm -v `pwd`:/workspace -v `pwd`/config.json:/kaniko/.docker/config.json:ro ghcr.io/osscontainertools/kaniko:latest --dockerfile=Dockerfile --destination=yourimagename
 
 After the image is uploaded, using the JFrog CLI, you can
 [collect](https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-PushingDockerImagesUsingKaniko)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,28 @@
+# Release Policy
+
+## Cadence
+
+kaniko ships on a fixed schedule, independent of what has been merged:
+
+- **Patch release** (`1.X.Y`) every two weeks — bug fixes only, no behavior changes.
+- **Minor release** (`1.X.0`) roughly every three months — new behavior is graduated from feature flags to defaults, and old flags are removed.
+
+The version number is decided in advance. A patch release will never contain behavior changes, regardless of what is available in the codebase. This means users can safely bump a patch version knowing nothing will behave differently.
+
+## Feature flags
+
+Because minor releases are infrequent, new behavior ships immediately behind a [feature flag](../README.md#feature-flags) rather than waiting for the next minor cycle. This gives users who want to try the feature early a way to opt in, while everyone else gets the usual patch-release stability guarantee.
+
+The graduation lifecycle of a feature flag is:
+
+1. **Introduced** — flag defaults to `false`, behavior is opt-in. Ships in the next patch release.
+2. **Becomes default** — flag defaults to `true` in the next minor release. Existing opt-in users are unaffected.
+3. **Deprecated** — flag is removed in a subsequent minor release.
+
+## Do I need a feature flag?
+
+The goal of a feature flag is to let users upgrade kaniko safely without surprises. Any change that could affect whether a build succeeds, what image it produces, or how long it takes should be gated behind a flag — even if the change is correct, even if it is a performance improvement, and even if the previous behavior was technically wrong. Some users will have built workflows around the old behavior and need time to migrate. Others will be running kaniko in environments where a new code path fails in ways the old one did not. A feature flag gives them the escape hatch.
+
+The only exception is a fix for behavior that was so broken that no working workflow could have depended on it — kaniko was erroring out, crashing, or producing corrupt images. There is no stable behavior to protect in that case, and making users wait three months for a minor release would cause more harm than the fix itself.
+
+When in doubt, open an issue and ask.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -19,6 +19,8 @@ The graduation lifecycle of a feature flag is:
 2. **Becomes default**: flag defaults to `true` in the next minor release. Existing opt-in users are unaffected.
 3. **Deprecated**: flag is removed in a subsequent minor release.
 
+This means a new behavior is opt-in for at least two weeks and up to three months, then opt-out for a further three months before the flag disappears entirely. Users have between three and six months to react to any change. We expect most users to upgrade roughly once per quarter rather than every two weeks, so in practice the full window is available to them.
+
 ## Do I need a feature flag?
 
 The goal of a feature flag is to let users upgrade kaniko safely without surprises. Any change that could affect whether a build succeeds, what image it produces, or how long it takes should be gated behind a flag, even if the change is correct, even if it is a performance improvement, and even if the previous behavior was technically wrong. Some users will have built workflows around the old behavior and need time to migrate. Others will be running kaniko in environments where a new code path fails in ways the old one did not. A feature flag gives them the escape hatch.
@@ -26,3 +28,7 @@ The goal of a feature flag is to let users upgrade kaniko safely without surpris
 The only exception is a fix for behavior that was so broken that no working workflow could have depended on it: kaniko was erroring out, crashing, or producing corrupt images. There is no stable behavior to protect in that case, and making users wait three months for a minor release would cause more harm than the fix itself.
 
 When in doubt, open an issue and ask.
+
+## Security fixes
+
+We do not cut special releases to address CVEs. Security fixes are committed to `main` immediately and ship as part of the normal release cycle. If you cannot wait for the next scheduled release, images built from `main` are available on [ghcr.io/osscontainertools/kaniko](https://github.com/orgs/osscontainertools/packages/container/package/kaniko) and go through the same automated testing as tagged releases.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -31,4 +31,4 @@ When in doubt, open an issue and ask.
 
 ## Security fixes
 
-We do not cut special releases to address CVEs. Security fixes are committed to `main` immediately and ship as part of the normal release cycle. If you cannot wait for the next scheduled release, images built from `main` are available as `ghcr.io/osscontainertools/kaniko-dev` and go through the same automated testing as tagged releases.
+We do not cut special releases to address CVEs. Security fixes are committed to `main` immediately and ship as part of the normal release cycle. If you cannot wait for the next scheduled release, images built from `main` are available as `ghcr.io/osscontainertools/kaniko-dev`, tagged with the commit hash, and go through the same automated testing as tagged releases.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,7 +11,7 @@ The version number is decided in advance. A patch release will never contain beh
 
 ## Feature flags
 
-Because minor releases are infrequent, new behavior ships immediately behind a [feature flag](../README.md#feature-flags) rather than waiting for the next minor cycle. This gives users who want to try the feature early a way to opt in, while everyone else gets the usual patch-release stability guarantee.
+Because minor releases are infrequent, new behavior ships immediately behind a [feature flag](../README.md#feature-flags) rather than waiting for the next minor cycle. This gives users who want to try the feature early a way to opt-in, while everyone else gets the usual patch-release stability guarantee.
 
 The graduation lifecycle of a feature flag is:
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -31,4 +31,4 @@ When in doubt, open an issue and ask.
 
 ## Security fixes
 
-We do not cut special releases to address CVEs. Security fixes are committed to `main` immediately and ship as part of the normal release cycle. If you cannot wait for the next scheduled release, images built from `main` are available on [ghcr.io/osscontainertools/kaniko](https://github.com/orgs/osscontainertools/packages/container/package/kaniko) and go through the same automated testing as tagged releases.
+We do not cut special releases to address CVEs. Security fixes are committed to `main` immediately and ship as part of the normal release cycle. If you cannot wait for the next scheduled release, images built from `main` are available as `ghcr.io/osscontainertools/kaniko-dev` and go through the same automated testing as tagged releases.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,8 +4,8 @@
 
 kaniko ships on a fixed schedule, independent of what has been merged:
 
-- **Patch release** (`1.X.Y`) every two weeks — bug fixes only, no behavior changes.
-- **Minor release** (`1.X.0`) roughly every three months — new behavior is graduated from feature flags to defaults, and old flags are removed.
+- **Patch release** (`1.X.Y`) every two weeks: bug fixes only, no behavior changes.
+- **Minor release** (`1.X.0`) roughly every three months: new behavior is graduated from feature flags to defaults, and old flags are removed.
 
 The version number is decided in advance. A patch release will never contain behavior changes, regardless of what is available in the codebase. This means users can safely bump a patch version knowing nothing will behave differently.
 
@@ -15,14 +15,14 @@ Because minor releases are infrequent, new behavior ships immediately behind a [
 
 The graduation lifecycle of a feature flag is:
 
-1. **Introduced** — flag defaults to `false`, behavior is opt-in. Ships in the next patch release.
-2. **Becomes default** — flag defaults to `true` in the next minor release. Existing opt-in users are unaffected.
-3. **Deprecated** — flag is removed in a subsequent minor release.
+1. **Introduced**: flag defaults to `false`, behavior is opt-in. Ships in the next patch release.
+2. **Becomes default**: flag defaults to `true` in the next minor release. Existing opt-in users are unaffected.
+3. **Deprecated**: flag is removed in a subsequent minor release.
 
 ## Do I need a feature flag?
 
-The goal of a feature flag is to let users upgrade kaniko safely without surprises. Any change that could affect whether a build succeeds, what image it produces, or how long it takes should be gated behind a flag — even if the change is correct, even if it is a performance improvement, and even if the previous behavior was technically wrong. Some users will have built workflows around the old behavior and need time to migrate. Others will be running kaniko in environments where a new code path fails in ways the old one did not. A feature flag gives them the escape hatch.
+The goal of a feature flag is to let users upgrade kaniko safely without surprises. Any change that could affect whether a build succeeds, what image it produces, or how long it takes should be gated behind a flag, even if the change is correct, even if it is a performance improvement, and even if the previous behavior was technically wrong. Some users will have built workflows around the old behavior and need time to migrate. Others will be running kaniko in environments where a new code path fails in ways the old one did not. A feature flag gives them the escape hatch.
 
-The only exception is a fix for behavior that was so broken that no working workflow could have depended on it — kaniko was erroring out, crashing, or producing corrupt images. There is no stable behavior to protect in that case, and making users wait three months for a minor release would cause more harm than the fix itself.
+The only exception is a fix for behavior that was so broken that no working workflow could have depended on it: kaniko was erroring out, crashing, or producing corrupt images. There is no stable behavior to protect in that case, and making users wait three months for a minor release would cause more harm than the fix itself.
 
 When in doubt, open an issue and ask.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -88,7 +88,6 @@ $ kubectl get pods
 NAME     READY   STATUS      RESTARTS   AGE
 kaniko   0/1     Completed   0          34s
 $ kubectl logs kaniko
-➜ kubectl logs kaniko
 INFO[0000] Resolved base name ubuntu to ubuntu
 INFO[0000] Resolved base name ubuntu to ubuntu
 INFO[0000] Downloading base image ubuntu
@@ -110,15 +109,15 @@ INFO[0001] ENTRYPOINT ["/bin/bash", "-c", "echo hello"]
 If as expected, the kaniko will build image and push to dockerhub successfully. Pull the image to local and run it to test:
 
 ```shell
-$ sudo docker run -it <user-name>/<repo-name>
-Unable to find image 'debuggy/helloworld:latest' locally
-latest: Pulling from debuggy/helloworld
+$ sudo docker run -it myuser/hello-kaniko
+Unable to find image 'myuser/hello-kaniko:latest' locally
+latest: Pulling from myuser/hello-kaniko
 5667fdb72017: Pull complete
 d83811f270d5: Pull complete
 ee671aafb583: Pull complete
 7fc152dfb3a6: Pull complete
 Digest: sha256:2707d17754ea99ce0cf15d84a7282ae746a44ff90928c2064755ee3b35c1057b
-Status: Downloaded newer image for debuggy/helloworld:latest
+Status: Downloaded newer image for myuser/hello-kaniko:latest
 hello
 ```
 

--- a/run_in_docker.sh
+++ b/run_in_docker.sh
@@ -24,7 +24,7 @@ fi
 dockerfile=$1
 context=$2
 destination=$3
-executor_image="martizih/kaniko:latest"
+executor_image="ghcr.io/osscontainertools/kaniko:latest"
 
 cache="false"
 if [[ -n "$4" ]]; then


### PR DESCRIPTION
## Summary

We went through the contributor-facing docs from the perspective of a new contributor and fixed what we found along the way.

- Fixed outdated references: removed GOPATH clone requirement, replaced kokoro CI references with GitHub Actions, updated all `gcr.io/kaniko-project/*` image references to `ghcr.io/osscontainertools/kaniko`, fixed stale `master` branch links
- Fixed tutorial copy-paste artifacts: mixed shell prompts, duplicate command line, inconsistent example image name
- Fixed integration test docs: replaced outdated `go test` invocations with make targets, corrected `DOCKERFILE_PATTERN` example, removed GCB benchmarking section
- Added contributor onboarding to `DEVELOPMENT.md`: Go version requirement, repository structure map, how to test with a locally-built binary, golden tests, testing philosophy, corrected commit message style guide
- Added `docs/releases.md` documenting the fixed release cadence (patch every 2 weeks, minor every 3 months), feature flag graduation lifecycle and the 3-6 month migration window, and the CVE/security fix policy