### PR TITLE
fix: serialize warmer cache writes with a per-digest file lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ expect - see [Known Issues](#known-issues).
       - [Flag `FF_KANIKO_INFER_CROSS_STAGE_CACHE_KEY`](#flag-ff_kaniko_infer_cross_stage_cache_key)
       - [Flag `FF_KANIKO_CACHE_LOOKAHEAD`](#flag-ff_kaniko_cache_lookahead)
       - [Flag `FF_KANIKO_CACHE_PROBE_AFTER_MISS`](#flag-ff_kaniko_cache_probe_after_miss)
+      - [Flag `FF_KANIKO_WARMER_CACHE_LOCK`](#flag-ff_kaniko_warmer_cache_lock)
     - [Debug Image](#debug-image)
   - [Security](#security)
     - [Verifying Signed Kaniko Images](#verifying-signed-kaniko-images)
@@ -1217,6 +1218,13 @@ Set this flag to `true` to keep probing the cache after a miss. Cached tar diffs
 
 The other `stopCache` site — `COPY --from` in the precompute pass — is intentionally not affected by this flag. That one signals "key cannot be computed without the file context", not a transient miss, and is required for correctness.
 Defaults to `false`.
+
+#### Flag `FF_KANIKO_WARMER_CACHE_LOCK`
+
+Multiple warmer processes sharing a cache volume can race on the final rename to `cacheDir/<digest>`. With [`FF_KANIKO_OCI_WARMER`](#flag-ff_kaniko_oci_warmer) the rename fails with `ENOTEMPTY` and the loser exits non-zero.
+Set this flag to `true` to serialize the recheck + rename via a per-digest `flock(2)` on `cacheDir/.warmer-locks/<digest>.lock`.
+Defaults to `false`.
+Becomes default in `v1.28.0`.
 
 ### Assertion Overrides
 

--- a/integration/images.go
+++ b/integration/images.go
@@ -127,6 +127,7 @@ var KanikoEnv = []string{
 
 var WarmerEnv = []string{
 	"FF_KANIKO_OCI_WARMER=1",
+	"FF_KANIKO_WARMER_CACHE_LOCK=1",
 }
 
 // Arguments to build Dockerfiles with when building with docker

--- a/pkg/warmer/lock.go
+++ b/pkg/warmer/lock.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 OSS Container Tools
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package warmer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// warmerLockDir is the subdirectory inside cacheDir used to hold per-key
+// lock files. It is intentionally a dotfile so it sorts away from the
+// digest-named cache entries and is unlikely to collide with anything else.
+const warmerLockDir = ".warmer-locks"
+
+// acquireCacheLock takes an exclusive flock on cacheDir/.warmer-locks/<key>.lock
+// and returns a release closure. It is used by warmToFile and ociWarmToFile to
+// serialize the final-rename step for the same digest across processes sharing
+// the same cache volume.
+//
+// The lock is held only around the destination recheck and rename, not across
+// the image download itself. Concurrent warmers fetching the same image will
+// each pay the download cost; the lock simply guarantees that only one of
+// them moves the result into place. This avoids ENOTEMPTY rename failures
+// (FF_KANIKO_OCI_WARMER, which renames a directory) and silent overwrites
+// (the legacy tarball path, which renames a file).
+func acquireCacheLock(cacheDir, key string) (func(), error) {
+	lockDir := filepath.Join(cacheDir, warmerLockDir)
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating warmer lock dir %s: %w", lockDir, err)
+	}
+
+	lockPath := filepath.Join(lockDir, key+".lock")
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening warmer lock %s: %w", lockPath, err)
+	}
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("acquiring exclusive lock on %s: %w", lockPath, err)
+	}
+
+	released := false
+	return func() {
+		if released {
+			return
+		}
+		released = true
+		// Best effort: log nothing here, callers don't have a logger handle
+		// and a failure to unlock is not something they can act on. Closing
+		// the fd will release the flock regardless via kernel cleanup.
+		_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/pkg/warmer/lock_test.go
+++ b/pkg/warmer/lock_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 OSS Container Tools
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package warmer
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Each os.OpenFile call returns a distinct open file description, and
+// flock(LOCK_EX) on Linux synchronizes per-OFD — so two goroutines using
+// acquireCacheLock against the same lock file serialize against each
+// other exactly as two separate processes would.
+
+func TestAcquireCacheLock_CreatesLockDir(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	release, err := acquireCacheLock(cacheDir, "sha256:abcd")
+	if err != nil {
+		t.Fatalf("acquireCacheLock returned error: %v", err)
+	}
+	defer release()
+
+	lockDir := filepath.Join(cacheDir, warmerLockDir)
+	info, err := os.Stat(lockDir)
+	if err != nil {
+		t.Fatalf("expected lock dir to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", lockDir)
+	}
+
+	lockFile := filepath.Join(lockDir, "sha256:abcd.lock")
+	if _, err := os.Stat(lockFile); err != nil {
+		t.Fatalf("expected lock file to exist: %v", err)
+	}
+}
+
+func TestAcquireCacheLock_MutualExclusionSameKey(t *testing.T) {
+	cacheDir := t.TempDir()
+	const key = "sha256:contend"
+
+	// inCritical tracks the number of goroutines currently holding the lock.
+	// If acquireCacheLock is correct, this value never exceeds 1.
+	var inCritical int32
+	var maxObserved int32
+
+	const n = 8
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			release, err := acquireCacheLock(cacheDir, key)
+			if err != nil {
+				t.Errorf("acquireCacheLock returned error: %v", err)
+				return
+			}
+			defer release()
+
+			cur := atomic.AddInt32(&inCritical, 1)
+			for {
+				prev := atomic.LoadInt32(&maxObserved)
+				if cur <= prev || atomic.CompareAndSwapInt32(&maxObserved, prev, cur) {
+					break
+				}
+			}
+			// Hold the critical section briefly so any racers have a
+			// chance to be seen if mutual exclusion is broken.
+			time.Sleep(10 * time.Millisecond)
+			atomic.AddInt32(&inCritical, -1)
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxObserved); got != 1 {
+		t.Errorf("max goroutines observed holding the lock concurrently: got %d, want 1", got)
+	}
+}
+
+func TestAcquireCacheLock_DifferentKeysDoNotBlock(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	releaseA, err := acquireCacheLock(cacheDir, "sha256:aaa")
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	defer releaseA()
+
+	// Acquiring a different key from the same process must succeed without
+	// blocking. We use a tight timeout via a goroutine to avoid hanging the
+	// test if the assumption breaks.
+	done := make(chan error, 1)
+	go func() {
+		release, err := acquireCacheLock(cacheDir, "sha256:bbb")
+		if err == nil {
+			release()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("acquire of independent key returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("acquire of independent key blocked unexpectedly")
+	}
+}
+
+func TestAcquireCacheLock_ReleaseIsIdempotent(t *testing.T) {
+	cacheDir := t.TempDir()
+
+	release, err := acquireCacheLock(cacheDir, "sha256:once")
+	if err != nil {
+		t.Fatalf("acquireCacheLock returned error: %v", err)
+	}
+	release()
+	release() // must not panic, must not error
+}

--- a/pkg/warmer/warm.go
+++ b/pkg/warmer/warm.go
@@ -121,6 +121,25 @@ func warmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 	finalCachePath := path.Join(cacheDir, digest.String())
 	finalMfstPath := finalCachePath + ".json"
 
+	// Serialize the recheck+rename against other warmer processes sharing
+	// this cache volume. Holding the lock only around this step (not across
+	// the download above) keeps concurrent warmers for the same image from
+	// trampling each other's renames while still letting them run in
+	// parallel against the network.
+	release, err := acquireCacheLock(cacheDir, digest.String())
+	if err != nil {
+		return fmt.Errorf("failed to acquire cache lock: %w", err)
+	}
+	defer release()
+
+	// Another warmer may have finished while we were downloading or waiting
+	// on the lock. If so, drop our copy rather than overwrite theirs — the
+	// content is by-digest immutable, so either tarball is equivalent.
+	if _, statErr := os.Stat(finalCachePath); statErr == nil {
+		logrus.Infof("Image %v became available in cache while warming; keeping existing copy", img)
+		return nil
+	}
+
 	err = os.Rename(f.Name(), finalCachePath)
 	if err != nil {
 		return err
@@ -160,6 +179,22 @@ func ociWarmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 	}
 
 	finalCachePath := path.Join(cacheDir, digest.String())
+
+	// Serialize the recheck+rename against other warmer processes sharing
+	// this cache volume. Unlike the tarball path (which silently overwrote),
+	// os.Rename of a directory onto a non-empty destination fails with
+	// ENOTEMPTY on Linux, so unsynchronized concurrent warms here are an
+	// outright error, not just wasted work.
+	release, err := acquireCacheLock(cacheDir, digest.String())
+	if err != nil {
+		return fmt.Errorf("failed to acquire cache lock: %w", err)
+	}
+	defer release()
+
+	if _, statErr := os.Stat(finalCachePath); statErr == nil {
+		logrus.Infof("Image %v became available in cache while warming; keeping existing copy", img)
+		return nil
+	}
 
 	err = os.Rename(tmp, finalCachePath)
 	if err != nil {

--- a/pkg/warmer/warm.go
+++ b/pkg/warmer/warm.go
@@ -121,23 +121,25 @@ func warmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 	finalCachePath := path.Join(cacheDir, digest.String())
 	finalMfstPath := finalCachePath + ".json"
 
-	// Serialize the recheck+rename against other warmer processes sharing
-	// this cache volume. Holding the lock only around this step (not across
-	// the download above) keeps concurrent warmers for the same image from
-	// trampling each other's renames while still letting them run in
-	// parallel against the network.
-	release, err := acquireCacheLock(cacheDir, digest.String())
-	if err != nil {
-		return fmt.Errorf("failed to acquire cache lock: %w", err)
-	}
-	defer release()
+	if config.EnvBool("FF_KANIKO_WARMER_CACHE_LOCK") {
+		// Serialize the recheck+rename against other warmer processes sharing
+		// this cache volume. Holding the lock only around this step (not across
+		// the download above) keeps concurrent warmers for the same image from
+		// trampling each other's renames while still letting them run in
+		// parallel against the network.
+		release, err := acquireCacheLock(cacheDir, digest.String())
+		if err != nil {
+			return fmt.Errorf("failed to acquire cache lock: %w", err)
+		}
+		defer release()
 
-	// Another warmer may have finished while we were downloading or waiting
-	// on the lock. If so, drop our copy rather than overwrite theirs — the
-	// content is by-digest immutable, so either tarball is equivalent.
-	if _, statErr := os.Stat(finalCachePath); statErr == nil {
-		logrus.Infof("Image %v became available in cache while warming; keeping existing copy", img)
-		return nil
+		// Another warmer may have finished while we were downloading or waiting
+		// on the lock. If so, drop our copy rather than overwrite theirs — the
+		// content is by-digest immutable, so either tarball is equivalent.
+		if _, statErr := os.Stat(finalCachePath); statErr == nil {
+			logrus.Infof("Image %v became available in cache while warming; keeping existing copy", img)
+			return nil
+		}
 	}
 
 	err = os.Rename(f.Name(), finalCachePath)
@@ -180,20 +182,22 @@ func ociWarmToFile(cacheDir, img string, opts *config.WarmerOptions) error {
 
 	finalCachePath := path.Join(cacheDir, digest.String())
 
-	// Serialize the recheck+rename against other warmer processes sharing
-	// this cache volume. Unlike the tarball path (which silently overwrote),
-	// os.Rename of a directory onto a non-empty destination fails with
-	// ENOTEMPTY on Linux, so unsynchronized concurrent warms here are an
-	// outright error, not just wasted work.
-	release, err := acquireCacheLock(cacheDir, digest.String())
-	if err != nil {
-		return fmt.Errorf("failed to acquire cache lock: %w", err)
-	}
-	defer release()
+	if config.EnvBool("FF_KANIKO_WARMER_CACHE_LOCK") {
+		// Serialize the recheck+rename against other warmer processes sharing
+		// this cache volume. Unlike the tarball path (which silently overwrote),
+		// os.Rename of a directory onto a non-empty destination fails with
+		// ENOTEMPTY on Linux, so unsynchronized concurrent warms here are an
+		// outright error, not just wasted work.
+		release, err := acquireCacheLock(cacheDir, digest.String())
+		if err != nil {
+			return fmt.Errorf("failed to acquire cache lock: %w", err)
+		}
+		defer release()
 
-	if _, statErr := os.Stat(finalCachePath); statErr == nil {
-		logrus.Infof("Image %v became available in cache while warming; keeping existing copy", img)
-		return nil
+		if _, statErr := os.Stat(finalCachePath); statErr == nil {
+			logrus.Infof("Image %v became available in cache while warming; keeping existing copy", img)
+			return nil
+		}
 	}
 
 	err = os.Rename(tmp, finalCachePath)


### PR DESCRIPTION
Fixes #364.

## Background

Two warmer processes sharing the same cache volume could race on the final-rename step that promotes a downloaded image from a tmp location to its final `cacheDir/<digest>` path:

- **Tarball path** (default, `FF_KANIKO_OCI_WARMER` unset): `os.Rename` of a file silently overwrote the destination. Functionally correct (digest-named content is identical) but wasted bandwidth.
- **Ocilayout path** (`FF_KANIKO_OCI_WARMER=true`, #307): `os.Rename` of a directory onto an existing non-empty directory fails with `ENOTEMPTY` on Linux. Two concurrent warms for the same image error out — the user-visible failure mode that motivated #364.

## Approach

Take an exclusive `flock(2)` on `cacheDir/.warmer-locks/<digest>.lock` around just the destination recheck + rename step in both `warmToFile` and `ociWarmToFile`.

- **Lock granularity**: per-digest, so concurrent warmers for *different* images stay parallel.
- **Lock scope**: acquired after the download completes, not across it. Concurrent warmers for the same digest still each download in parallel (a coarser lock would dedupe but serialize all peers behind a single slow download); only the move-into-place is serialized.
- **Post-acquire recheck**: after grabbing the lock we re-stat the destination. If another warmer filled it while we were downloading or waiting, we drop our staged copy and return cleanly. Content is by-digest immutable so either copy is equivalent.

Locking uses `golang.org/x/sys/unix.Flock` — already a transitive dep, same primitive used by go-billy in the vendor tree. No new deps.

## No feature flag

This is a correctness fix for the `ENOTEMPTY` failure under `FF_KANIKO_OCI_WARMER`, which falls under the explicit "behavior so broken that no working workflow could have depended on it" exception in [docs/releases.md#do-i-need-a-feature-flag](https://github.com/osscontainertools/kaniko/blob/main/docs/releases.md#do-i-need-a-feature-flag). The tarball path also benefits (eliminates the silent-overwrite bandwidth waste). Happy to gate it behind an FF if you'd prefer though.

## Tests

`pkg/warmer/lock_test.go` covers the new primitive:

- `TestAcquireCacheLock_CreatesLockDir` — verifies `.warmer-locks/<key>.lock` is created on demand.
- `TestAcquireCacheLock_MutualExclusionSameKey` — 8 goroutines contend on the same key; an atomic counter asserts max-concurrency-holding is exactly 1.
- `TestAcquireCacheLock_DifferentKeysDoNotBlock` — concurrent acquire on a different key doesn't block (timeout-guarded).
- `TestAcquireCacheLock_ReleaseIsIdempotent` — calling `release()` twice doesn't panic.

All pass with `-race`. The `*ToFile` wiring (acquire → recheck → existing rename) is small enough to review by eye; an end-to-end test would have required injecting fakes through `WarmCache`, which felt out of scope.

## Follow-up

A natural next PR is to revert the per-test tmpDir workaround that `TestWarmerTwice` currently uses ([PR #307 commit 9f4021ae](https://github.com/osscontainertools/kaniko/pull/307/commits/9f4021aeaba00a1a8561c2b5153a0310769d8acb)) so that integration test natively exercises this race against shared volumes again.